### PR TITLE
GitHub: CODEOWNERS anlegen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners – alle Dateien
+* @oeme-github @msusky

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Thumbs.db
 
 # Generierte Dateien (bei Bedarf neu erstellen)
 *.pdf
+*.docx


### PR DESCRIPTION
## Zusammenfassung
- `.github/CODEOWNERS` angelegt
- Alle Dateien sind `@oeme-github` und `@msusky` zugewiesen
- Voraussetzung dafür, dass der Ruleset „Require review from Code Owners" greift

## Testplan
- [ ] Nach dem Merge prüfen, ob GitHub den Ruleset korrekt auswertet
- [ ] Testweise PR öffnen und prüfen, ob Code-Owner-Review angefordert wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)