### PR TITLE
Widget: Freitextsuche mit Highlighting (R2.2)

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,7 +9,7 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v2 | 2026-04-25 | Design, Phasen-Header, 4 Filterebenen |
+| `patientenpfad_interaktiv.html` | v3 | 2026-04-25 | Freitextsuche mit Highlighting ergänzt |
 | `patientenpfad_editor.html` | v1 | 2026-04-25 | Neu: Formular-Editor mit Meta-Verwaltung und Export |
 | `patientenpfad_data.js` | v2 | 2026-04-25 | meta-Objekt, akteur/objekt/gesetze als Arrays |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
@@ -133,7 +133,7 @@ Ziel: Eine interaktive, pflegbare Prozesslandkarte, die in der Arbeitsgruppe gen
 | ID | Anforderung | Priorität | Status |
 |---|---|---|---|
 | R2.1 | Zähler anzeigen: „X von 25 Prozessschritten sichtbar" | Hoch | Erledigt |
-| R2.2 | Freitextsuche über Titel, Akteur, Objekt | Mittel | Offen |
+| R2.2 | Freitextsuche über Titel, Akteur, Objekt | Mittel | Erledigt (mit Highlighting) |
 | R2.3 | `sendPrompt()`-Button entfernen – toter Platzhalter | Hoch | Erledigt |
 | R2.4 | Detailkarte: `nr`, `domäne`, `standards` und `gesetze` anzeigen, sobald befüllt | Mittel | Erledigt |
 | R2.5 | Druckansicht / Export (alle sichtbaren Karten als strukturierte Übersicht) | Niedrig | Offen |
@@ -194,7 +194,9 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 
 ## Technische Hinweise (für Claude Code)
 
-- Alle 25 Prozessschritte sind im `data`-Array in `patientenpfad_interaktiv.html` definiert
-- Jeder Eintrag hat: `phase`, `titel`, `akteur`, `objekt`, `op`, `dr` (Datenräume), `detail`
+- Daten liegen in `patientenpfad_data.js` — nicht in der HTML-Datei
+- `meta`-Objekt enthält pflegbare Auswahllisten: `domaenen`, `akteure`, `datenobjekte`, `rechtsgrundlagen`
+- `data`-Array: 25 Einträge mit `nr`, `phase`, `titel`, `akteur[]`, `objekt[]`, `op`, `dr[]`, `domäne`, `gesetze[]`, `detail`
 - Die vier Datenräume sind: `portal`, `versorgung`, `epa`, `ehds`
-- `sendPrompt()` ist ein Claude.ai-Platzhalter – in Claude Code durch eigene Logik ersetzen
+- Viewer und Editor laden `patientenpfad_data.js` per `<script src="...">`
+- Suche im Viewer: kombiniert mit allen Filtern, Highlighting via `<mark>`-Tags

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -111,7 +111,9 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 |---|---|---|
 | `patientenpfad_arbeitsdokument.md` als Word-Datei bereitstellen | Du | Erledigt (lokal per Pandoc generiert, nicht eingecheckt) |
 | HTML-Widget weiter verbessern | Claude | In Arbeit – Kernfunktionen erledigt (siehe Requirements) |
-| PR #2 (CODEOWNERS + .gitignore) mergen | oeme-github | Offen |
+| PR #2 (CODEOWNERS + .gitignore) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
+| PR #3 (Widget v2) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
+| PR #4 (Freitextsuche) mergen | oeme-github | Offen |
 
 ---
 

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -330,6 +330,29 @@
       margin-bottom: 4px;
     }
 
+    /* ── Suche ── */
+    .search-input {
+      flex: 1;
+      max-width: 340px;
+      padding: 5px 10px;
+      border: 1px solid var(--c-border-2);
+      border-radius: var(--r-sm);
+      font-size: 13px;
+      font-family: inherit;
+      color: var(--c-text-1);
+      background: var(--c-surface);
+      transition: border-color 0.12s;
+    }
+    .search-input:focus { outline: none; border-color: var(--c-border-3); }
+    .search-input::placeholder { color: var(--c-text-4); }
+
+    mark {
+      background: #FEF08A;
+      color: inherit;
+      border-radius: 2px;
+      padding: 0 1px;
+    }
+
     /* ── Print ── */
     @media print {
       body { background: white; }
@@ -373,6 +396,12 @@
       <span class="filter-label">Rechtsgrundlage</span>
       <!-- dynamisch befüllt -->
     </div>
+    <div class="filter-row">
+      <span class="filter-label">Suche</span>
+      <input class="search-input" type="search" id="search-input"
+             placeholder="Titel, Akteur, Datenobjekt, Beschreibung …"
+             oninput="setSearch(this.value)">
+    </div>
   </div>
 
   <div class="main">
@@ -403,6 +432,7 @@
     let activeDR    = new Set(['portal','versorgung','epa','ehds']);
     let activeLaws  = new Set(allLawGroups);
     let openCard    = null;
+    let searchTerm  = '';
 
     // ── Law-Filter-Buttons dynamisch aufbauen ────────────────────────
     const lawRow = document.getElementById('law-filter-row');
@@ -441,6 +471,28 @@
       render();
     }
 
+    function setSearch(val) {
+      searchTerm = val.trim();
+      render();
+    }
+
+    function highlight(text, term) {
+      if (!term) return text;
+      const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>');
+    }
+
+    function matchesSearch(d) {
+      if (!searchTerm) return true;
+      const q = searchTerm.toLowerCase();
+      return (
+        d.titel.toLowerCase().includes(q) ||
+        d.akteur.join(', ').toLowerCase().includes(q) ||
+        d.objekt.join(' · ').toLowerCase().includes(q) ||
+        d.detail.toLowerCase().includes(q)
+      );
+    }
+
     // ── Karte als HTML ───────────────────────────────────────────────
     function renderCard(d) {
       const hasDR  = d.dr.some(r => activeDR.has(r));
@@ -465,7 +517,7 @@
 
         detailHtml = `
           <div class="detail-box">
-            <div>${d.detail}</div>
+            <div>${highlight(d.detail, searchTerm)}</div>
             <div class="detail-section">
               <div class="detail-section-label">Informationsdomäne</div>
               ${domaene}
@@ -483,10 +535,10 @@
           <div class="card-meta">
             <span class="card-nr">#${String(d.nr).padStart(2,'0')}</span>
           </div>
-          <div class="card-titel">${d.titel}</div>
-          <div class="card-akteur">${d.akteur.join(', ')}</div>
+          <div class="card-titel">${highlight(d.titel, searchTerm)}</div>
+          <div class="card-akteur">${highlight(d.akteur.join(', '), searchTerm)}</div>
           <div class="card-objekt">
-            ${d.objekt.join(' · ')}<span class="card-op">${d.op}</span>
+            ${highlight(d.objekt.join(' · '), searchTerm)}<span class="card-op">${d.op}</span>
           </div>
           <div class="card-badges">${drBadges}</div>
           ${detailHtml}
@@ -502,7 +554,9 @@
       let totalVisible = 0;
 
       const sectionsHtml = phases.map(phase => {
-        const phaseDaten = data.filter(d => d.phase === phase);
+        const phaseDaten = data
+          .filter(d => d.phase === phase)
+          .filter(matchesSearch);
         const visibleCount = phaseDaten.filter(d =>
           d.dr.some(r => activeDR.has(r)) &&
           (d.gesetze || []).some(g => activeLaws.has(getLawGroup(g)))


### PR DESCRIPTION
## Zusammenfassung

- Freitextsuche in der Toolbar (4. Filterzeile)
- Suche kombiniert mit allen aktiven Filtern (Phase, Datenraum, Rechtsgrundlage)
- Nicht-treffende Karten werden ausgeblendet
- Treffer werden hervorgehoben in: Titel, Akteur, Datenobjekt, Beschreibung
- Highlighting auch in der aufgeklappten Detailkarte

## Noch offen

- [ ] Standards-Feld FHIR/IHE/HL7 (R1.3)
- [ ] Export PDF / CSV (R4)
- [ ] Rechtsgrundlagen durch AG fachlich prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)