### PR TITLE
Standards: meta.standards, Struktur-Kennzeichen, KIM (R1.3)

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,9 +9,9 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v4 | 2026-04-25 | Export PDF/CSV/JSON, Filterzeile im Druck |
-| `patientenpfad_editor.html` | v1 | 2026-04-25 | Neu: Formular-Editor mit Meta-Verwaltung und Export |
-| `patientenpfad_data.js` | v2 | 2026-04-25 | meta-Objekt, akteur/objekt/gesetze als Arrays |
+| `patientenpfad_interaktiv.html` | v5 | 2026-04-25 | Standards + Struktur-Badge ergänzt |
+| `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
+| `patientenpfad_data.js` | v3 | 2026-04-25 | meta.standards (32 Einträge + KIM), struktur-Feld alle 25 Schritte |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `KONTEXT.md` | – | 2026-04-25 | Lebendes Dokument, kein Versionsschema |
@@ -117,7 +117,8 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | PR #3 (Widget v2) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #4 (Freitextsuche) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #5 (AK Patientenportale) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
-| PR #6 (Export PDF/CSV/JSON) mergen | oeme-github | Offen |
+| PR #6 (Export PDF/CSV/JSON) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
+| PR #7 (Standards + Struktur-Kennzeichen) mergen | oeme-github | Offen |
 
 ---
 
@@ -131,7 +132,7 @@ Ziel: Eine interaktive, pflegbare Prozesslandkarte, die in der Arbeitsgruppe gen
 |---|---|---|---|
 | R1.1 | Laufende Nummer `nr` (1–25) pro Prozessschritt ergänzen | Hoch | Erledigt |
 | R1.2 | Feld `domäne` ergänzen – Zuordnung zu einer der 14 Informationsdomänen (Kap. 5) | Hoch | Erledigt |
-| R1.3 | Feld `standards` ergänzen – zunächst leer, später mit FHIR/IHE/HL7 befüllen | Mittel | Offen |
+| R1.3 | Feld `standards` ergänzen – zunächst leer, später mit FHIR/IHE/HL7 befüllen | Mittel | Erledigt (Entwurf – Review durch AG) |
 | R1.4 | Feld `gesetze` ergänzen – Zuordnung relevanter Rechtsgrundlagen pro Schritt (z.B. DSGVO Art. 9, SGB V § 291a, PatDatSchG, KHZG) | Hoch | Erledigt (Entwurf – Review durch AG) |
 
 ### R2 – Benutzeroberfläche verbessern

--- a/patientenpfad_data.js
+++ b/patientenpfad_data.js
@@ -1,6 +1,6 @@
 // Patientenpfad – Daten und Konfiguration
 //
-// Felder: nr, phase, titel, akteur[], objekt[], op, dr[], domäne, gesetze[], detail
+// Felder: nr, phase, titel, akteur[], objekt[], op, dr[], domäne, gesetze[], standards[], detail
 // phase:  'vor' | 'im' | 'nach'
 // op:     E = Erzeugt, V = Verändert, G = Gelöscht
 // Exportiert: 2026-04-25
@@ -62,6 +62,41 @@ const meta = {
     "Widerspruch"
   ],
 
+  standards: [
+    "ABDA Medikationsliste",
+    "DICOM",
+    "gematik ePA-Spezifikation",
+    "gematik TI-Messenger",
+    "gematik VSDM",
+    "HL7 CDA R2",
+    "HL7 FHIR R4 (Appointment)",
+    "HL7 FHIR R4 (CarePlan)",
+    "HL7 FHIR R4 (Communication)",
+    "HL7 FHIR R4 (Condition)",
+    "HL7 FHIR R4 (Consent)",
+    "HL7 FHIR R4 (DiagnosticReport)",
+    "HL7 FHIR R4 (DocumentReference)",
+    "HL7 FHIR R4 (Encounter)",
+    "HL7 FHIR R4 (EpisodeOfCare)",
+    "HL7 FHIR R4 (MedicationStatement)",
+    "HL7 FHIR R4 (Observation)",
+    "HL7 FHIR R4 (QuestionnaireResponse)",
+    "HL7 FHIR R4 (ServiceRequest)",
+    "HL7 v2",
+    "ICD-10-GM",
+    "IHE MHD",
+    "IHE PIX/PDQ",
+    "IHE RAD",
+    "IHE XDS.b",
+    "ISiK Basismodul",
+    "ISiK Terminplanung",
+    "KBV FHIR-Basisprofile",
+    "KBV Medikationsplan",
+    "LOINC",
+    "OPS",
+    "SNOMED CT"
+  ],
+
   rechtsgrundlagen: [
     "AMVV § 14",
     "BGB § 630a (Behandlungsvertrag)",
@@ -106,6 +141,9 @@ const meta = {
 // ── Prozessschritte ───────────────────────────────────────────────────────────
 
 const data = [
+
+  // ── Vor dem Krankenhaus ──────────────────────────────────────────────────────
+
   {
     nr: 1,
     phase: "vor",
@@ -116,6 +154,7 @@ const data = [
     dr: ["portal", "versorgung"],
     domäne: "Termin",
     gesetze: ["DSGVO Art. 6 Abs. 1", "SGB V § 75 (Terminvermittlung)"],
+    standards: ["HL7 FHIR R4 (Appointment)", "ISiK Terminplanung"],
     detail: "Terminvereinbarung für ambulante Vorstellung oder stationäre Aufnahme. Das Portal ist die primäre Schnittstelle – der Patient löst den Prozess aus."
   },
   {
@@ -128,6 +167,7 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Überweisung",
     gesetze: ["SGB V § 73 (Überweisungen)", "DSGVO Art. 9"],
+    standards: ["HL7 FHIR R4 (ServiceRequest)", "KBV FHIR-Basisprofile", "HL7 CDA R2"],
     detail: "Die Überweisung wird im Kontext des Krankenhauses erstmalig bereitgestellt. Heute oft noch als Papier oder PDF – ein klassischer Medienbruch."
   },
   {
@@ -140,6 +180,7 @@ const data = [
     dr: ["portal", "versorgung"],
     domäne: "Patient",
     gesetze: ["DSGVO Art. 6 + Art. 9", "SGB V § 291 (eGK)", "KHEntgG § 2"],
+    standards: ["HL7 FHIR R4 (Patient)", "IHE PIX/PDQ", "gematik VSDM", "ISiK Basismodul"],
     detail: "Kontaktdaten und Versicherungsdaten werden erfasst oder aktualisiert. Datenobjekt kann sowohl neu entstehen als auch verändert werden."
   },
   {
@@ -152,6 +193,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630g (Akteneinsicht)", "SGB V § 341 ff. (ePA)"],
+    standards: ["HL7 FHIR R4 (DocumentReference)", "IHE XDS.b", "IHE MHD", "gematik ePA-Spezifikation"],
     detail: "Upload oder Zugriff auf vorhandene Dokumente. Idealerweise strukturierte Datenobjekte – nicht PDFs."
   },
   {
@@ -164,6 +206,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Anamnese",
     gesetze: ["DSGVO Art. 9", "BGB § 630a (Behandlungsvertrag)"],
+    standards: ["HL7 FHIR R4 (QuestionnaireResponse)", "HL7 CDA R2"],
     detail: "Digitale medizinische Vorgeschichte. Zentrales Datenobjekt – wird im gesamten Pfad weitergenutzt. Sollte strukturiert vorliegen, nicht als Freitext."
   },
   {
@@ -176,8 +219,12 @@ const data = [
     dr: ["portal", "versorgung", "epa", "ehds"],
     domäne: "Einwilligung",
     gesetze: ["DSGVO Art. 7 + Art. 9", "BGB § 630d (Einwilligung)", "SGB V § 342 (ePA-Einwilligung)"],
+    standards: ["HL7 FHIR R4 (Consent)", "gematik ePA-Spezifikation"],
     detail: "Datenschutz und Behandlungseinwilligung. Einwilligung und Widerspruch sind eigenständige Datenobjekte mit unterschiedlicher rechtlicher Wirkung."
   },
+
+  // ── Im Krankenhaus ───────────────────────────────────────────────────────────
+
   {
     nr: 7,
     phase: "im",
@@ -188,6 +235,7 @@ const data = [
     dr: ["portal", "versorgung"],
     domäne: "Patient",
     gesetze: ["DSGVO Art. 6", "SGB V § 39", "KHZG"],
+    standards: ["HL7 FHIR R4 (Encounter)", "IHE PIX/PDQ", "ISiK Basismodul"],
     detail: "Bestätigung der Anwesenheit. Auslöser des stationären Prozesses – verbindet das Portal mit der Verwaltung."
   },
   {
@@ -200,6 +248,7 @@ const data = [
     dr: ["versorgung"],
     domäne: "Patient",
     gesetze: ["DSGVO Art. 9", "KHEntgG § 2", "SGB V § 39"],
+    standards: ["HL7 v2", "HL7 FHIR R4 (Encounter)", "ISiK Basismodul"],
     detail: "Fallanlage im KIS. Zentrales Datenobjekt für den gesamten stationären Aufenthalt."
   },
   {
@@ -212,6 +261,7 @@ const data = [
     dr: ["versorgung"],
     domäne: "Pflege",
     gesetze: ["DSGVO Art. 9", "SGB XI § 14 (Pflegebedürftigkeit)", "KrPflG"],
+    standards: ["HL7 FHIR R4 (Observation)", "SNOMED CT", "LOINC"],
     detail: "Erfassung des pflegerischen Bedarfs bei Aufnahme – Mobilität, Ernährung, Risikoscreening. Eigenständiges Datenobjekt der Pflege."
   },
   {
@@ -224,6 +274,7 @@ const data = [
     dr: ["versorgung", "epa", "ehds"],
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630a (Behandlungsvertrag)", "MBO-Ä § 10"],
+    standards: ["HL7 FHIR R4 (DiagnosticReport)", "LOINC", "DICOM", "IHE RAD"],
     detail: "Untersuchungen und Diagnostik. Erzeugt medizinische Kerndaten – sollten strukturiert vorliegen für optimale Weiterverarbeitung."
   },
   {
@@ -236,6 +287,7 @@ const data = [
     dr: ["versorgung", "epa", "ehds"],
     domäne: "Diagnosen",
     gesetze: ["DSGVO Art. 9", "BGB § 630f (Dokumentationspflicht)", "MBO-Ä § 10"],
+    standards: ["HL7 FHIR R4 (Condition)", "ICD-10-GM", "OPS", "HL7 CDA R2"],
     detail: "Befunde und Diagnosen werden dokumentiert. Zentrales Datenobjekt – wird laufend verändert und ergänzt."
   },
   {
@@ -248,6 +300,7 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Pflege",
     gesetze: ["DSGVO Art. 9", "BGB § 630f (Dokumentationspflicht)", "SGB XI"],
+    standards: ["HL7 FHIR R4 (Observation)", "SNOMED CT", "LOINC"],
     detail: "Laufende Dokumentation von Pflegemaßnahmen, Vitalwerten und Verlauf. Wird kontinuierlich ergänzt."
   },
   {
@@ -260,6 +313,7 @@ const data = [
     dr: ["portal", "versorgung"],
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630g (Akteneinsicht)", "KHZG", "SGB V § 341 ff. (ePA)"],
+    standards: ["HL7 FHIR R4 (DocumentReference)", "gematik ePA-Spezifikation", "ISiK Basismodul"],
     detail: "Ausgewählte Informationen werden dem Patienten im Portal bereitgestellt – z.B. Laborwerte. Strukturierte Daten ermöglichen eine sinnvolle Darstellung."
   },
   {
@@ -272,6 +326,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
+    standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
     detail: "Nachrichten und Rückfragen – unabhängig vom Übertragungsweg (Portal, TI-Messenger oder andere Kanäle)."
   },
   {
@@ -284,6 +339,7 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "DSGVO Art. 9"],
+    standards: ["HL7 FHIR R4 (EpisodeOfCare)", "HL7 CDA R2", "ISiK Basismodul"],
     detail: "Organisation der Entlassung. Auslöser für mehrere nachgelagerte Prozesse – Pflegeüberleitung, AHB, Nachsorgetermin."
   },
   {
@@ -296,6 +352,7 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB XI § 37", "DSGVO Art. 9"],
+    standards: ["HL7 FHIR R4 (CarePlan)", "SNOMED CT"],
     detail: "Pflegerische Bedarfserfassung und Weitergabe. Eigenständiges Datenobjekt – intern für die Planung."
   },
   {
@@ -308,6 +365,7 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB XI § 37", "DSGVO Art. 9"],
+    standards: ["HL7 FHIR R4 (CarePlan)", "IHE XDS.b", "HL7 CDA R2"],
     detail: "Bedarfserfassung und Organisation der pflegerischen Weiterversorgung. Das Überleitungsdokument geht an die nachversorgende Einrichtung."
   },
   {
@@ -320,8 +378,12 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Nachsorge",
     gesetze: ["SGB V § 40 (Anschlussheilbehandlung)", "SGB IX", "DSGVO Art. 9"],
+    standards: ["HL7 FHIR R4 (ServiceRequest)", "KBV FHIR-Basisprofile"],
     detail: "Antragstellung und Weiterleitung an Kostenträger. Erzeugt ein eigenständiges Datenobjekt mit Weiterleitung an externe Akteure."
   },
+
+  // ── Nach dem Krankenhaus ─────────────────────────────────────────────────────
+
   {
     nr: 19,
     phase: "nach",
@@ -332,6 +394,7 @@ const data = [
     dr: ["portal", "versorgung", "epa", "ehds"],
     domäne: "Dokumente",
     gesetze: ["BGB § 630f + § 630g", "DSGVO Art. 9", "SGB V § 39 (Entlassmanagement)", "MBO-Ä § 10"],
+    standards: ["HL7 CDA R2", "HL7 FHIR R4 (DocumentReference)", "IHE XDS.b", "gematik ePA-Spezifikation"],
     detail: "Arztbrief und Befunde nach Entlassung. Zentrales Übergabedokument – sollte strukturiert vorliegen, nicht nur als PDF."
   },
   {
@@ -344,6 +407,7 @@ const data = [
     dr: ["portal", "versorgung", "epa", "ehds"],
     domäne: "Medikation",
     gesetze: ["SGB V § 31a (Medikationsplan)", "DSGVO Art. 9", "AMVV § 14"],
+    standards: ["HL7 FHIR R4 (MedicationStatement)", "KBV Medikationsplan", "ABDA Medikationsliste"],
     detail: "Aktueller Medikationsplan nach Entlassung. Klassisches Konsistenzproblem – existiert heute oft mehrfach und nicht synchronisiert."
   },
   {
@@ -356,6 +420,7 @@ const data = [
     dr: ["epa", "ehds"],
     domäne: "Dokumente",
     gesetze: ["SGB V § 341–360 (ePA)", "DSGVO Art. 9", "PatDatSchG"],
+    standards: ["HL7 FHIR R4 (DocumentReference)", "IHE MHD", "gematik ePA-Spezifikation"],
     detail: "Upload strukturierter Datenobjekte in die ePA. Ziel: keine Dokumente, sondern maschinenlesbare strukturierte Daten."
   },
   {
@@ -368,6 +433,7 @@ const data = [
     dr: ["portal", "versorgung"],
     domäne: "Termin",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB V § 75a", "DSGVO Art. 6"],
+    standards: ["HL7 FHIR R4 (Appointment)", "ISiK Terminplanung"],
     detail: "Terminplanung nach Entlassung. Portal als primäre Schnittstelle für den Patienten."
   },
   {
@@ -380,6 +446,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Verlauf",
     gesetze: ["DSGVO Art. 9", "SGB V § 68a (DiGA)", "DiGAV"],
+    standards: ["HL7 FHIR R4 (QuestionnaireResponse)", "HL7 FHIR R4 (Observation)", "LOINC"],
     detail: "Fragebögen und PROMs nach Entlassung. Patient als aktiver Datenerzeuger – strukturierte Rückmeldungen ermöglichen Automatisierung."
   },
   {
@@ -392,6 +459,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
+    standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
     detail: "Rückfragen nach Entlassung – unabhängig vom Übertragungsweg."
   },
   {
@@ -404,6 +472,8 @@ const data = [
     dr: ["versorgung", "epa"],
     domäne: "Dokumente",
     gesetze: ["BGB § 630f (Dokumentationspflicht)", "DSGVO Art. 9", "KHEntgG", "SGB V § 301"],
+    standards: ["HL7 FHIR R4 (EpisodeOfCare)", "IHE XDS.b", "HL7 CDA R2"],
     detail: "Behandlungsfall wird abgeschlossen. Finales Datenobjekt des Patientenpfads."
   }
+
 ];

--- a/patientenpfad_data.js
+++ b/patientenpfad_data.js
@@ -69,6 +69,7 @@ const meta = {
     "gematik ePA-Spezifikation",
     "gematik TI-Messenger",
     "gematik VSDM",
+    "KIM (Kommunikation im Medizinwesen)",
     "HL7 CDA R2",
     "HL7 FHIR R4 (Appointment)",
     "HL7 FHIR R4 (CarePlan)",
@@ -340,7 +341,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
-    standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
+    standards: ["gematik TI-Messenger", "KIM (Kommunikation im Medizinwesen)", "HL7 FHIR R4 (Communication)"],
     struktur: "unstrukturiert",
     detail: "Nachrichten und Rückfragen – unabhängig vom Übertragungsweg (Portal, TI-Messenger oder andere Kanäle)."
   },
@@ -483,7 +484,7 @@ const data = [
     dr: ["portal", "versorgung", "epa"],
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
-    standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
+    standards: ["gematik TI-Messenger", "KIM (Kommunikation im Medizinwesen)", "HL7 FHIR R4 (Communication)"],
     struktur: "unstrukturiert",
     detail: "Rückfragen nach Entlassung – unabhängig vom Übertragungsweg."
   },

--- a/patientenpfad_data.js
+++ b/patientenpfad_data.js
@@ -1,6 +1,7 @@
 // Patientenpfad – Daten und Konfiguration
 //
-// Felder: nr, phase, titel, akteur[], objekt[], op, dr[], domäne, gesetze[], standards[], detail
+// Felder: nr, phase, titel, akteur[], objekt[], op, dr[], domäne, gesetze[], standards[], struktur, detail
+// struktur: 'strukturiert' | 'teilstrukturiert' | 'unstrukturiert'  — Ist-Zustand des erzeugten Datenobjekts
 // phase:  'vor' | 'im' | 'nach'
 // op:     E = Erzeugt, V = Verändert, G = Gelöscht
 // Exportiert: 2026-04-25
@@ -155,6 +156,7 @@ const data = [
     domäne: "Termin",
     gesetze: ["DSGVO Art. 6 Abs. 1", "SGB V § 75 (Terminvermittlung)"],
     standards: ["HL7 FHIR R4 (Appointment)", "ISiK Terminplanung"],
+    struktur: "unstrukturiert",
     detail: "Terminvereinbarung für ambulante Vorstellung oder stationäre Aufnahme. Das Portal ist die primäre Schnittstelle – der Patient löst den Prozess aus."
   },
   {
@@ -168,6 +170,7 @@ const data = [
     domäne: "Überweisung",
     gesetze: ["SGB V § 73 (Überweisungen)", "DSGVO Art. 9"],
     standards: ["HL7 FHIR R4 (ServiceRequest)", "KBV FHIR-Basisprofile", "HL7 CDA R2"],
+    struktur: "unstrukturiert",
     detail: "Die Überweisung wird im Kontext des Krankenhauses erstmalig bereitgestellt. Heute oft noch als Papier oder PDF – ein klassischer Medienbruch."
   },
   {
@@ -181,6 +184,7 @@ const data = [
     domäne: "Patient",
     gesetze: ["DSGVO Art. 6 + Art. 9", "SGB V § 291 (eGK)", "KHEntgG § 2"],
     standards: ["HL7 FHIR R4 (Patient)", "IHE PIX/PDQ", "gematik VSDM", "ISiK Basismodul"],
+    struktur: "strukturiert",
     detail: "Kontaktdaten und Versicherungsdaten werden erfasst oder aktualisiert. Datenobjekt kann sowohl neu entstehen als auch verändert werden."
   },
   {
@@ -194,6 +198,7 @@ const data = [
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630g (Akteneinsicht)", "SGB V § 341 ff. (ePA)"],
     standards: ["HL7 FHIR R4 (DocumentReference)", "IHE XDS.b", "IHE MHD", "gematik ePA-Spezifikation"],
+    struktur: "unstrukturiert",
     detail: "Upload oder Zugriff auf vorhandene Dokumente. Idealerweise strukturierte Datenobjekte – nicht PDFs."
   },
   {
@@ -207,6 +212,7 @@ const data = [
     domäne: "Anamnese",
     gesetze: ["DSGVO Art. 9", "BGB § 630a (Behandlungsvertrag)"],
     standards: ["HL7 FHIR R4 (QuestionnaireResponse)", "HL7 CDA R2"],
+    struktur: "unstrukturiert",
     detail: "Digitale medizinische Vorgeschichte. Zentrales Datenobjekt – wird im gesamten Pfad weitergenutzt. Sollte strukturiert vorliegen, nicht als Freitext."
   },
   {
@@ -220,6 +226,7 @@ const data = [
     domäne: "Einwilligung",
     gesetze: ["DSGVO Art. 7 + Art. 9", "BGB § 630d (Einwilligung)", "SGB V § 342 (ePA-Einwilligung)"],
     standards: ["HL7 FHIR R4 (Consent)", "gematik ePA-Spezifikation"],
+    struktur: "unstrukturiert",
     detail: "Datenschutz und Behandlungseinwilligung. Einwilligung und Widerspruch sind eigenständige Datenobjekte mit unterschiedlicher rechtlicher Wirkung."
   },
 
@@ -236,6 +243,7 @@ const data = [
     domäne: "Patient",
     gesetze: ["DSGVO Art. 6", "SGB V § 39", "KHZG"],
     standards: ["HL7 FHIR R4 (Encounter)", "IHE PIX/PDQ", "ISiK Basismodul"],
+    struktur: "strukturiert",
     detail: "Bestätigung der Anwesenheit. Auslöser des stationären Prozesses – verbindet das Portal mit der Verwaltung."
   },
   {
@@ -249,6 +257,7 @@ const data = [
     domäne: "Patient",
     gesetze: ["DSGVO Art. 9", "KHEntgG § 2", "SGB V § 39"],
     standards: ["HL7 v2", "HL7 FHIR R4 (Encounter)", "ISiK Basismodul"],
+    struktur: "strukturiert",
     detail: "Fallanlage im KIS. Zentrales Datenobjekt für den gesamten stationären Aufenthalt."
   },
   {
@@ -262,6 +271,7 @@ const data = [
     domäne: "Pflege",
     gesetze: ["DSGVO Art. 9", "SGB XI § 14 (Pflegebedürftigkeit)", "KrPflG"],
     standards: ["HL7 FHIR R4 (Observation)", "SNOMED CT", "LOINC"],
+    struktur: "unstrukturiert",
     detail: "Erfassung des pflegerischen Bedarfs bei Aufnahme – Mobilität, Ernährung, Risikoscreening. Eigenständiges Datenobjekt der Pflege."
   },
   {
@@ -275,6 +285,7 @@ const data = [
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630a (Behandlungsvertrag)", "MBO-Ä § 10"],
     standards: ["HL7 FHIR R4 (DiagnosticReport)", "LOINC", "DICOM", "IHE RAD"],
+    struktur: "teilstrukturiert",
     detail: "Untersuchungen und Diagnostik. Erzeugt medizinische Kerndaten – sollten strukturiert vorliegen für optimale Weiterverarbeitung."
   },
   {
@@ -288,6 +299,7 @@ const data = [
     domäne: "Diagnosen",
     gesetze: ["DSGVO Art. 9", "BGB § 630f (Dokumentationspflicht)", "MBO-Ä § 10"],
     standards: ["HL7 FHIR R4 (Condition)", "ICD-10-GM", "OPS", "HL7 CDA R2"],
+    struktur: "teilstrukturiert",
     detail: "Befunde und Diagnosen werden dokumentiert. Zentrales Datenobjekt – wird laufend verändert und ergänzt."
   },
   {
@@ -301,6 +313,7 @@ const data = [
     domäne: "Pflege",
     gesetze: ["DSGVO Art. 9", "BGB § 630f (Dokumentationspflicht)", "SGB XI"],
     standards: ["HL7 FHIR R4 (Observation)", "SNOMED CT", "LOINC"],
+    struktur: "teilstrukturiert",
     detail: "Laufende Dokumentation von Pflegemaßnahmen, Vitalwerten und Verlauf. Wird kontinuierlich ergänzt."
   },
   {
@@ -314,6 +327,7 @@ const data = [
     domäne: "Befunde",
     gesetze: ["DSGVO Art. 9", "BGB § 630g (Akteneinsicht)", "KHZG", "SGB V § 341 ff. (ePA)"],
     standards: ["HL7 FHIR R4 (DocumentReference)", "gematik ePA-Spezifikation", "ISiK Basismodul"],
+    struktur: "teilstrukturiert",
     detail: "Ausgewählte Informationen werden dem Patienten im Portal bereitgestellt – z.B. Laborwerte. Strukturierte Daten ermöglichen eine sinnvolle Darstellung."
   },
   {
@@ -327,6 +341,7 @@ const data = [
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
     standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
+    struktur: "unstrukturiert",
     detail: "Nachrichten und Rückfragen – unabhängig vom Übertragungsweg (Portal, TI-Messenger oder andere Kanäle)."
   },
   {
@@ -340,6 +355,7 @@ const data = [
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "DSGVO Art. 9"],
     standards: ["HL7 FHIR R4 (EpisodeOfCare)", "HL7 CDA R2", "ISiK Basismodul"],
+    struktur: "unstrukturiert",
     detail: "Organisation der Entlassung. Auslöser für mehrere nachgelagerte Prozesse – Pflegeüberleitung, AHB, Nachsorgetermin."
   },
   {
@@ -353,6 +369,7 @@ const data = [
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB XI § 37", "DSGVO Art. 9"],
     standards: ["HL7 FHIR R4 (CarePlan)", "SNOMED CT"],
+    struktur: "unstrukturiert",
     detail: "Pflegerische Bedarfserfassung und Weitergabe. Eigenständiges Datenobjekt – intern für die Planung."
   },
   {
@@ -366,6 +383,7 @@ const data = [
     domäne: "Nachsorge",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB XI § 37", "DSGVO Art. 9"],
     standards: ["HL7 FHIR R4 (CarePlan)", "IHE XDS.b", "HL7 CDA R2"],
+    struktur: "unstrukturiert",
     detail: "Bedarfserfassung und Organisation der pflegerischen Weiterversorgung. Das Überleitungsdokument geht an die nachversorgende Einrichtung."
   },
   {
@@ -379,6 +397,7 @@ const data = [
     domäne: "Nachsorge",
     gesetze: ["SGB V § 40 (Anschlussheilbehandlung)", "SGB IX", "DSGVO Art. 9"],
     standards: ["HL7 FHIR R4 (ServiceRequest)", "KBV FHIR-Basisprofile"],
+    struktur: "unstrukturiert",
     detail: "Antragstellung und Weiterleitung an Kostenträger. Erzeugt ein eigenständiges Datenobjekt mit Weiterleitung an externe Akteure."
   },
 
@@ -395,6 +414,7 @@ const data = [
     domäne: "Dokumente",
     gesetze: ["BGB § 630f + § 630g", "DSGVO Art. 9", "SGB V § 39 (Entlassmanagement)", "MBO-Ä § 10"],
     standards: ["HL7 CDA R2", "HL7 FHIR R4 (DocumentReference)", "IHE XDS.b", "gematik ePA-Spezifikation"],
+    struktur: "unstrukturiert",
     detail: "Arztbrief und Befunde nach Entlassung. Zentrales Übergabedokument – sollte strukturiert vorliegen, nicht nur als PDF."
   },
   {
@@ -408,6 +428,7 @@ const data = [
     domäne: "Medikation",
     gesetze: ["SGB V § 31a (Medikationsplan)", "DSGVO Art. 9", "AMVV § 14"],
     standards: ["HL7 FHIR R4 (MedicationStatement)", "KBV Medikationsplan", "ABDA Medikationsliste"],
+    struktur: "teilstrukturiert",
     detail: "Aktueller Medikationsplan nach Entlassung. Klassisches Konsistenzproblem – existiert heute oft mehrfach und nicht synchronisiert."
   },
   {
@@ -421,6 +442,7 @@ const data = [
     domäne: "Dokumente",
     gesetze: ["SGB V § 341–360 (ePA)", "DSGVO Art. 9", "PatDatSchG"],
     standards: ["HL7 FHIR R4 (DocumentReference)", "IHE MHD", "gematik ePA-Spezifikation"],
+    struktur: "unstrukturiert",
     detail: "Upload strukturierter Datenobjekte in die ePA. Ziel: keine Dokumente, sondern maschinenlesbare strukturierte Daten."
   },
   {
@@ -434,6 +456,7 @@ const data = [
     domäne: "Termin",
     gesetze: ["SGB V § 39 (Entlassmanagement)", "SGB V § 75a", "DSGVO Art. 6"],
     standards: ["HL7 FHIR R4 (Appointment)", "ISiK Terminplanung"],
+    struktur: "strukturiert",
     detail: "Terminplanung nach Entlassung. Portal als primäre Schnittstelle für den Patienten."
   },
   {
@@ -447,6 +470,7 @@ const data = [
     domäne: "Verlauf",
     gesetze: ["DSGVO Art. 9", "SGB V § 68a (DiGA)", "DiGAV"],
     standards: ["HL7 FHIR R4 (QuestionnaireResponse)", "HL7 FHIR R4 (Observation)", "LOINC"],
+    struktur: "teilstrukturiert",
     detail: "Fragebögen und PROMs nach Entlassung. Patient als aktiver Datenerzeuger – strukturierte Rückmeldungen ermöglichen Automatisierung."
   },
   {
@@ -460,6 +484,7 @@ const data = [
     domäne: "Kommunikation",
     gesetze: ["DSGVO Art. 9", "StGB § 203 (Schweigepflicht)", "TKG"],
     standards: ["gematik TI-Messenger", "HL7 FHIR R4 (Communication)"],
+    struktur: "unstrukturiert",
     detail: "Rückfragen nach Entlassung – unabhängig vom Übertragungsweg."
   },
   {
@@ -473,6 +498,7 @@ const data = [
     domäne: "Dokumente",
     gesetze: ["BGB § 630f (Dokumentationspflicht)", "DSGVO Art. 9", "KHEntgG", "SGB V § 301"],
     standards: ["HL7 FHIR R4 (EpisodeOfCare)", "IHE XDS.b", "HL7 CDA R2"],
+    struktur: "strukturiert",
     detail: "Behandlungsfall wird abgeschlossen. Finales Datenobjekt des Patientenpfads."
   }
 

--- a/patientenpfad_editor.html
+++ b/patientenpfad_editor.html
@@ -275,6 +275,15 @@
               <label class="form-label">Operation (E / V / G)</label>
               <input class="form-input" type="text" id="f-op" value="${item.op||''}" placeholder="z.B. E, V">
             </div>
+            <div class="form-field">
+              <label class="form-label">Struktur (Ist-Zustand)</label>
+              <select class="form-select" id="f-struktur">
+                <option value="">– bitte wählen –</option>
+                <option value="strukturiert"     ${item.struktur==='strukturiert'?'selected':''}>Strukturiert</option>
+                <option value="teilstrukturiert" ${item.struktur==='teilstrukturiert'?'selected':''}>Teilstrukturiert</option>
+                <option value="unstrukturiert"   ${item.struktur==='unstrukturiert'?'selected':''}>Unstrukturiert</option>
+              </select>
+            </div>
             <div class="form-field full">
               <label class="form-label">Titel</label>
               <input class="form-input" type="text" id="f-titel" value="${item.titel||''}" placeholder="Titel des Prozessschritts">
@@ -351,6 +360,7 @@
         'domäne': document.getElementById('f-domaene').value,
         gesetze:   getChecked('gesetze'),
         standards: getChecked('standards'),
+        struktur:  document.getElementById('f-struktur').value,
         detail:   document.getElementById('f-detail').value.trim(),
       };
       editIdx = null;

--- a/patientenpfad_editor.html
+++ b/patientenpfad_editor.html
@@ -190,7 +190,8 @@
       { key: 'domaenen',        label: 'Informationsdomänen' },
       { key: 'akteure',         label: 'Akteure' },
       { key: 'datenobjekte',    label: 'Datenobjekte' },
-      { key: 'rechtsgrundlagen',label: 'Rechtsgrundlagen' }
+      { key: 'rechtsgrundlagen',label: 'Rechtsgrundlagen' },
+      { key: 'standards',       label: 'Standards' }
     ];
 
     function renderMeta() {
@@ -307,6 +308,12 @@
               </div>
             </div>
             <div class="form-field full">
+              <label class="form-label">Standards <span style="font-weight:400;text-transform:none;letter-spacing:0;">(Entwurf)</span></label>
+              <div class="check-group scrollable" id="f-standards">
+                ${renderCheckGroup('standards', metaCopy.standards||[], item.standards||[], false)}
+              </div>
+            </div>
+            <div class="form-field full">
               <label class="form-label">Beschreibung</label>
               <textarea class="form-textarea" id="f-detail" placeholder="Kurze Beschreibung des Prozessschritts">${item.detail||''}</textarea>
             </div>
@@ -342,7 +349,8 @@
         op:       document.getElementById('f-op').value.trim(),
         dr:       getChecked('dr'),
         'domäne': document.getElementById('f-domaene').value,
-        gesetze:  getChecked('gesetze'),
+        gesetze:   getChecked('gesetze'),
+        standards: getChecked('standards'),
         detail:   document.getElementById('f-detail').value.trim(),
       };
       editIdx = null;

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -330,6 +330,19 @@
       margin-bottom: 4px;
     }
 
+    .standard-chip {
+      display: inline-block;
+      padding: 3px 9px;
+      border-radius: var(--r-sm);
+      font-size: 11px;
+      font-weight: 500;
+      background: #EFF6FF;
+      color: #1E40AF;
+      border: 1px solid #BFDBFE;
+      margin-right: 4px;
+      margin-bottom: 4px;
+    }
+
     /* ── Suche ── */
     .search-input {
       flex: 1;
@@ -576,6 +589,10 @@
             <div class="detail-section">
               <div class="detail-section-label">Rechtsgrundlagen <span style="font-weight:400;text-transform:none;letter-spacing:0;">(Entwurf)</span></div>
               <div>${gesetze}</div>
+            </div>
+            <div class="detail-section">
+              <div class="detail-section-label">Standards <span style="font-weight:400;text-transform:none;letter-spacing:0;">(Entwurf)</span></div>
+              <div>${(d.standards||[]).length ? d.standards.map(s=>`<span class="standard-chip">${highlight(s,searchTerm)}</span>`).join('') : '<span style="color:var(--c-text-4);font-size:12px;">–</span>'}</div>
             </div>
           </div>`;
       }

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -330,6 +330,21 @@
       margin-bottom: 4px;
     }
 
+    .struktur-badge {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 20px;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-left: 6px;
+      vertical-align: middle;
+    }
+    .struktur-strukturiert   { background: #D1FAE5; color: #065F46; border: 1px solid #6EE7B7; }
+    .struktur-teilstrukturiert { background: #FEF3C7; color: #78350F; border: 1px solid #FCD34D; }
+    .struktur-unstrukturiert { background: #FEE2E2; color: #7F1D1D; border: 1px solid #FCA5A5; }
+
     .standard-chip {
       display: inline-block;
       padding: 3px 9px;
@@ -606,7 +621,7 @@
           <div class="card-titel">${highlight(d.titel, searchTerm)}</div>
           <div class="card-akteur">${highlight(d.akteur.join(', '), searchTerm)}</div>
           <div class="card-objekt">
-            ${highlight(d.objekt.join(' · '), searchTerm)}<span class="card-op">${d.op}</span>
+            ${highlight(d.objekt.join(' · '), searchTerm)}<span class="card-op">${d.op}</span>${d.struktur ? `<span class="struktur-badge struktur-${d.struktur}">${d.struktur}</span>` : ''}
           </div>
           <div class="card-badges">${drBadges}</div>
           ${detailHtml}


### PR DESCRIPTION
## Zusammenfassung

- **`meta.standards`** mit 33 Einträgen (FHIR, IHE, gematik, KBV, ISiK, Terminologien u.a.)
- **Entwurf-Zuordnung** für alle 25 Prozessschritte — Review durch AG erforderlich
- **KIM** (Kommunikation im Medizinwesen) ergänzt in meta und Schritten #14 + #24
- **Struktur-Kennzeichen** pro Schritt: `strukturiert` / `teilstrukturiert` / `unstrukturiert`
- **Viewer**: Standards als blaue Chips in der Detailkarte, Struktur-Badge direkt auf der Karte (grün/gelb/rot)
- **Editor**: Standards als Checkbox-Liste, Struktur als Select-Feld

## Verteilung Ist-Zustand (Entwurf)
- 4× strukturiert · 5× teilstrukturiert · 16× unstrukturiert

## Noch offen
- [ ] Standards und Struktur-Zuordnungen durch AG fachlich prüfen und korrigieren
- [ ] R2.5 Druckansicht (bereits via PDF-Export abgedeckt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)