### PR TITLE
Widget: Standards-Filter + Alle aufklappen/zuklappen

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,7 +9,7 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v5 | 2026-04-25 | Standards + Struktur-Badge ergänzt |
+| `patientenpfad_interaktiv.html` | v6 | 2026-04-25 | Standards-Filter, Alle aufklappen/zuklappen |
 | `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
 | `patientenpfad_data.js` | v3 | 2026-04-25 | meta.standards (32 Einträge + KIM), struktur-Feld alle 25 Schritte |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
@@ -112,13 +112,14 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | Aufgabe | Wer | Status |
 |---|---|---|
 | `patientenpfad_arbeitsdokument.md` als Word-Datei bereitstellen | Du | Erledigt (lokal per Pandoc generiert, nicht eingecheckt) |
-| HTML-Widget weiter verbessern | Claude | In Arbeit – Kernfunktionen erledigt (siehe Requirements) |
+| HTML-Widget weiter verbessern | Claude | Abgeschlossen – alle Requirements R1–R4 erledigt |
 | PR #2 (CODEOWNERS + .gitignore) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #3 (Widget v2) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #4 (Freitextsuche) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #5 (AK Patientenportale) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #6 (Export PDF/CSV/JSON) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
-| PR #7 (Standards + Struktur-Kennzeichen) mergen | oeme-github | Offen |
+| PR #7 (Standards + Struktur-Kennzeichen) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
+| PR #8 (Standards-Filter + Auf-/Zuklappen) mergen | oeme-github | Offen |
 
 ---
 

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -405,6 +405,27 @@
     }
     .btn-export:hover { border-color: var(--c-border-3); color: var(--c-text-1); }
 
+    /* ── Standard-Toggles ── */
+    .std-toggle {
+      padding: 4px 10px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--c-border-2);
+      background: var(--c-surface);
+      color: var(--c-text-3);
+      font-size: 11px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s;
+      opacity: 0.45;
+    }
+    .std-toggle.active {
+      background: #EFF6FF;
+      border-color: #BFDBFE;
+      color: #1E40AF;
+      opacity: 1;
+    }
+    .std-toggle:hover:not(.active) { border-color: var(--c-border-3); color: var(--c-text-2); opacity: 0.8; }
+
     /* ── Print-Filterzeile ── */
     .print-filter-summary {
       display: none;
@@ -469,6 +490,10 @@
       <span class="filter-label">Rechtsgrundlage</span>
       <!-- dynamisch befüllt -->
     </div>
+    <div class="filter-row" id="std-filter-row">
+      <span class="filter-label">Standard</span>
+      <!-- dynamisch befüllt -->
+    </div>
     <div class="filter-row">
       <span class="filter-label">Suche</span>
       <input class="search-input" type="search" id="search-input"
@@ -480,6 +505,7 @@
   <div class="main">
     <div class="export-bar">
       <div class="counter" id="counter"></div>
+      <button class="btn-export" id="btn-expand" onclick="toggleExpandAll()">⊞ Alle aufklappen</button>
       <button class="btn-export" onclick="exportPDF()" title="Druckansicht öffnen">↓ PDF</button>
       <button class="btn-export" onclick="exportCSV()" title="Sichtbare Schritte als CSV">↓ CSV</button>
       <button class="btn-export" onclick="exportJSON()" title="Sichtbare Schritte als JSON">↓ JSON</button>
@@ -500,20 +526,37 @@
       return gesetz.split(/\s+(?:§|Art\.|Abs\.)/)[0].trim();
     }
 
-    // ── Alle Gesetzesgruppen aus den Daten ermitteln ─────────────────
+    // ── Standardgruppe aus einem Eintrag extrahieren ─────────────────
+    function getStandardGroup(s) {
+      if (s.startsWith('HL7 FHIR'))                          return 'HL7 FHIR';
+      if (s.startsWith('HL7'))                               return 'HL7';
+      if (s.startsWith('IHE'))                               return 'IHE';
+      if (s.startsWith('gematik'))                           return 'gematik';
+      if (s.startsWith('KBV') || s.startsWith('ISiK'))      return 'KBV / ISiK';
+      if (['SNOMED CT','LOINC','ICD-10-GM','OPS'].includes(s)) return 'Terminologien';
+      return 'Sonstige';
+    }
+
+    // ── Alle Gruppen aus den Daten ermitteln ─────────────────────────
     const allLawGroups = [...new Set(
       data.flatMap(d => (d.gesetze || []).map(getLawGroup))
     )].sort();
 
-    // ── Filter-State ─────────────────────────────────────────────────
-    let activePhase = 'alle';
-    let activeDR    = new Set(['portal','versorgung','epa','ehds']);
-    let activeLaws  = new Set(allLawGroups);
-    let openCard    = null;
-    let searchTerm  = '';
-    let printMode   = false;
+    const allStandardGroups = [...new Set(
+      data.flatMap(d => (d.standards || []).map(getStandardGroup))
+    )].sort();
 
-    // ── Law-Filter-Buttons dynamisch aufbauen ────────────────────────
+    // ── Filter-State ─────────────────────────────────────────────────
+    let activePhase     = 'alle';
+    let activeDR        = new Set(['portal','versorgung','epa','ehds']);
+    let activeLaws      = new Set(allLawGroups);
+    let activeStandards = new Set(allStandardGroups);
+    let openCard        = null;
+    let searchTerm      = '';
+    let printMode       = false;
+    let expandAll       = false;
+
+    // ── Filter-Buttons dynamisch aufbauen ────────────────────────────
     const lawRow = document.getElementById('law-filter-row');
     allLawGroups.forEach(group => {
       const btn = document.createElement('button');
@@ -522,6 +565,16 @@
       btn.textContent = group;
       btn.onclick = () => toggleLaw(group);
       lawRow.appendChild(btn);
+    });
+
+    const stdRow = document.getElementById('std-filter-row');
+    allStandardGroups.forEach(group => {
+      const btn = document.createElement('button');
+      btn.className = 'std-toggle active';
+      btn.dataset.std = group;
+      btn.textContent = group;
+      btn.onclick = () => toggleStandard(group);
+      stdRow.appendChild(btn);
     });
 
     // ── Event-Handler ────────────────────────────────────────────────
@@ -545,8 +598,23 @@
       render();
     }
 
+    function toggleStandard(group) {
+      activeStandards.has(group) ? activeStandards.delete(group) : activeStandards.add(group);
+      document.querySelector(`[data-std="${CSS.escape(group)}"]`).classList.toggle('active', activeStandards.has(group));
+      render();
+    }
+
     function toggleDetail(nr) {
-      openCard = openCard === nr ? null : nr;
+      expandAll = false;
+      openCard  = openCard === nr ? null : nr;
+      render();
+    }
+
+    function toggleExpandAll() {
+      expandAll = !expandAll;
+      openCard  = null;
+      const btn = document.getElementById('btn-expand');
+      btn.textContent = expandAll ? '⊟ Alle zuklappen' : '⊞ Alle aufklappen';
       render();
     }
 
@@ -574,11 +642,11 @@
 
     // ── Karte als HTML ───────────────────────────────────────────────
     function renderCard(d) {
-      const hasDR  = d.dr.some(r => activeDR.has(r));
-      const hasLaw = !d.gesetze || d.gesetze.length === 0
-        || d.gesetze.some(g => activeLaws.has(getLawGroup(g)));
-      const dimmed = !hasDR || !hasLaw;
-      const isOpen = openCard === d.nr || printMode;
+      const hasDR       = d.dr.some(r => activeDR.has(r));
+      const hasLaw      = !d.gesetze   || d.gesetze.length   === 0 || d.gesetze.some(g => activeLaws.has(getLawGroup(g)));
+      const hasStandard = !d.standards || d.standards.length === 0 || d.standards.some(s => activeStandards.has(getStandardGroup(s)));
+      const dimmed = !hasDR || !hasLaw || !hasStandard;
+      const isOpen = openCard === d.nr || printMode || expandAll;
 
       const drBadges = d.dr
         .map(r => `<span class="dr-badge ${drBadgeClass[r]}">${drLabel[r]}</span>`)
@@ -642,7 +710,8 @@
           .filter(matchesSearch);
         const visibleCount = phaseDaten.filter(d =>
           d.dr.some(r => activeDR.has(r)) &&
-          (d.gesetze || []).some(g => activeLaws.has(getLawGroup(g)))
+          (d.gesetze   || []).some(g => activeLaws.has(getLawGroup(g))) &&
+          (!d.standards || d.standards.length === 0 || d.standards.some(s => activeStandards.has(getStandardGroup(s))))
         ).length;
         totalVisible += visibleCount;
 
@@ -668,16 +737,18 @@
       document.getElementById('karten').innerHTML = sectionsHtml;
 
       // Print-Filterzeile aktualisieren
-      const phaseText  = activePhase === 'alle' ? 'Alle Phasen' : phaseLabel[activePhase];
-      const drText     = activeDR.size === 4 ? 'Alle Datenräume' : [...activeDR].map(r => drLabel[r]).join(', ');
-      const lawText    = activeLaws.size === allLawGroups.length ? 'Alle Rechtsgrundlagen' : [...activeLaws].join(', ');
-      const searchText = searchTerm ? `Suche: „${searchTerm}"` : null;
+      const phaseText    = activePhase === 'alle' ? 'Alle Phasen' : phaseLabel[activePhase];
+      const drText       = activeDR.size === 4 ? 'Alle Datenräume' : [...activeDR].map(r => drLabel[r]).join(', ');
+      const lawText      = activeLaws.size === allLawGroups.length ? 'Alle Rechtsgrundlagen' : [...activeLaws].join(', ');
+      const stdText      = activeStandards.size === allStandardGroups.length ? null : `Standards: ${[...activeStandards].join(', ')}`;
+      const searchText   = searchTerm ? `Suche: „${searchTerm}"` : null;
       const dateText   = new Date().toLocaleDateString('de-DE', { day:'2-digit', month:'2-digit', year:'numeric' });
 
       const parts = [
         `Phase: ${phaseText}`,
         `Datenräume: ${drText}`,
         `Rechtsgrundlagen: ${lawText}`,
+        stdText,
         searchText
       ].filter(Boolean).join(' · ');
 


### PR DESCRIPTION
## Zusammenfassung

- **Standards-Filter** (5. Filterzeile): 7 Kategorien — HL7 FHIR, HL7, IHE, gematik, KBV/ISiK, Terminologien, Sonstige. Karten werden gedimmt wenn kein Standard zur aktiven Kategorie passt. Aktiver Filter erscheint in der PDF-Druckzeile.
- **Alle aufklappen / Alle zuklappen**: Button neben dem Zähler öffnet oder schließt alle sichtbaren Karten. Einzelklick auf eine Karte schaltet zurück in den Einzelmodus.

## Alle Requirements abgeschlossen
R1 (Datenstruktur) · R2 (UI) · R3 (Pflegbarkeit) · R4 (Export) — alle erledigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)