### PR TITLE
Viewer: Matrix-Ansicht Informationsdomänen × Datenräume (Issue #13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Alle Ausgaben, Commit-Messages, Kommentare und Dokumente auf Deutsch.
 1. `git status` und `git log --oneline -5` ausführen — was liegt offen?
 2. `git pull` — aktuellen Stand holen
 3. `KONTEXT.md` lesen — aktuellen Arbeitsstand verstehen
-4. User fragen: Was ist heute das Ziel?
+4. `gh issue list --state open` ausführen — offene Issues anzeigen
+5. User fragen: Was ist heute das Ziel?
 
 ---
 

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,7 +9,7 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v9 | 2026-04-30 | Matrix-Ansicht als zweiter Tab (Issue #13) |
+| `patientenpfad_interaktiv.html` | v10 | 2026-04-30 | Matrix-Ansicht + Popup-Detail beim Chip-Klick |
 | `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
 | `patientenpfad_data.js` | v4 | 2026-04-29 | DIN EN ISO/IEEE 11073 ergänzt (meta + Schritte 9, 10, 12) |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
@@ -124,7 +124,7 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | PR #8 (Standards-Filter + Auf-/Zuklappen + Struktur-Filter) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #10 (Struktur-Filter + CLAUDE.md Commit-Konventionen) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | Issue #12 (DIN EN ISO/IEEE 11073 ergänzen) | Claude | Erledigt (2026-04-29) |
-| Issue #13 (Matrix-Ansicht Domänen × Datenräume) | Claude | Erledigt (2026-04-30) – PR #15 |
+| Issue #13 (Matrix-Ansicht Domänen × Datenräume) | Claude | Erledigt (2026-04-30) – PR #15 (inkl. Popup) |
 | Issue #14 (Ist-Analyse) | AG | Offen – wartet auf Entscheidung der Arbeitsgruppe |
 
 ---

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,14 +9,15 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v8 | 2026-04-25 | Struktur-Filter als Filter-Zeile im Toolbar |
+| `patientenpfad_interaktiv.html` | v9 | 2026-04-30 | Matrix-Ansicht als zweiter Tab (Issue #13) |
 | `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
 | `patientenpfad_data.js` | v4 | 2026-04-29 | DIN EN ISO/IEEE 11073 ergänzt (meta + Schritte 9, 10, 12) |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
-| `KONTEXT.md` | – | 2026-04-29 | Lebendes Dokument, kein Versionsschema |
+| `KONTEXT.md` | – | 2026-04-30 | Session 2026-04-30 abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
+| `CLAUDE.md` | – | 2026-04-30 | Issue-Check in Start-Routine ergänzt |
 
 ---
 
@@ -123,6 +124,8 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | PR #8 (Standards-Filter + Auf-/Zuklappen + Struktur-Filter) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #10 (Struktur-Filter + CLAUDE.md Commit-Konventionen) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | Issue #12 (DIN EN ISO/IEEE 11073 ergänzen) | Claude | Erledigt (2026-04-29) |
+| Issue #13 (Matrix-Ansicht Domänen × Datenräume) | Claude | Erledigt (2026-04-30) – PR #15 |
+| Issue #14 (Ist-Analyse) | AG | Offen – wartet auf Entscheidung der Arbeitsgruppe |
 
 ---
 
@@ -190,6 +193,10 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 ---
 
 ## Offene Punkte & nächste Schritte
+
+### Im Tool
+- Issue #14 (Ist-Analyse) – wartet auf Entscheidung der AG: strukturiert in Daten aufnehmen oder im Word-Dokument belassen?
+- R2.5 (Druckansicht/Export) – Priorität Niedrig, noch offen
 
 ### Im Dokument
 - Systemebene (Kap. 8) könnte um weitere Ist-Analyse-Beispiele ergänzt werden

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -445,6 +445,52 @@
     }
     .std-toggle:hover:not(.active) { border-color: var(--c-border-3); color: var(--c-text-2); opacity: 0.8; }
 
+    /* ── Modal ── */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.35);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 200;
+    }
+    .modal-panel {
+      background: var(--c-surface);
+      border-radius: var(--r-lg);
+      padding: 22px 24px 24px;
+      max-width: 580px;
+      width: 92%;
+      max-height: 82vh;
+      overflow-y: auto;
+      box-shadow: 0 12px 40px rgba(0,0,0,0.22);
+      position: relative;
+      border-left: 4px solid transparent;
+    }
+    .modal-panel.phase-vor  { border-left-color: var(--phase-vor); }
+    .modal-panel.phase-im   { border-left-color: var(--phase-im); }
+    .modal-panel.phase-nach { border-left-color: var(--phase-nach); }
+    .modal-close {
+      position: absolute;
+      top: 10px;
+      right: 14px;
+      background: none;
+      border: none;
+      font-size: 20px;
+      line-height: 1;
+      cursor: pointer;
+      color: var(--c-text-3);
+      padding: 2px 6px;
+      border-radius: var(--r-sm);
+      font-family: inherit;
+    }
+    .modal-close:hover { color: var(--c-text-1); background: var(--c-bg); }
+    .modal-nr   { font-size: 11px; font-weight: 600; color: var(--c-text-4); margin-bottom: 4px; }
+    .modal-titel { font-size: 17px; font-weight: 700; color: var(--c-text-1); margin-bottom: 8px; line-height: 1.3; }
+    .modal-meta  { font-size: 12px; color: var(--c-text-3); margin-bottom: 4px; }
+    .modal-badges { display: flex; flex-wrap: wrap; gap: 4px; margin: 10px 0 14px; }
+    .modal-divider { border: none; border-top: 1px solid var(--c-border-1); margin: 14px 0; }
+
     /* ── Print-Filterzeile ── */
     .print-filter-summary {
       display: none;
@@ -636,6 +682,13 @@
     </div>
     <div id="karten"></div>
     <div id="matrix-view" style="display:none;"></div>
+  </div>
+
+  <div class="modal-overlay" id="step-modal" style="display:none;" onclick="closeModal(event)">
+    <div class="modal-panel" id="modal-panel" onclick="event.stopPropagation()">
+      <button class="modal-close" onclick="closeModal()">×</button>
+      <div id="modal-content"></div>
+    </div>
   </div>
 
   <script src="patientenpfad_data.js"></script>
@@ -945,7 +998,7 @@
           const steps = matrix[domäne][dr];
           if (!steps.length) return `<td></td>`;
           const chips = steps.map(s =>
-            `<button class="matrix-step-chip phase-${s.phase}" data-nr="${s.nr}" onclick="goToStep(${s.nr})">#${String(s.nr).padStart(2,'0')} ${s.titel}</button>`
+            `<button class="matrix-step-chip phase-${s.phase}" data-nr="${s.nr}" onclick="openModal(${s.nr})">#${String(s.nr).padStart(2,'0')} ${s.titel}</button>`
           ).join('');
           return `<td>${chips}</td>`;
         }).join('');
@@ -961,15 +1014,59 @@
         </div>`;
     }
 
-    function goToStep(nr) {
-      switchView('karten');
-      openCard = nr;
-      render();
-      setTimeout(() => {
-        const card = document.querySelector(`.prozess-card[data-nr="${nr}"]`);
-        if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }, 50);
+    function openModal(nr) {
+      const d = data.find(s => s.nr === nr);
+      if (!d) return;
+
+      const drBadges = d.dr
+        .map(r => `<span class="dr-badge ${drBadgeClass[r]}">${drLabel[r]}</span>`)
+        .join('');
+      const strukturBadge = d.struktur
+        ? `<span class="struktur-badge struktur-${d.struktur}">${d.struktur}</span>` : '';
+      const domaeneHtml = d.domäne
+        ? `<span class="domaene-chip">${d.domäne}</span>`
+        : `<span style="color:var(--c-text-4);font-size:12px;">–</span>`;
+      const gesetzeHtml = (d.gesetze || []).length
+        ? d.gesetze.map(g => `<span class="gesetz-chip">${g}</span>`).join('')
+        : `<span style="color:var(--c-text-4);font-size:12px;">–</span>`;
+      const standardsHtml = (d.standards || []).length
+        ? d.standards.map(s => `<span class="standard-chip">${s}</span>`).join('')
+        : `<span style="color:var(--c-text-4);font-size:12px;">–</span>`;
+
+      document.getElementById('modal-content').innerHTML = `
+        <div class="modal-nr">#${String(d.nr).padStart(2,'0')} · ${phaseLabel[d.phase]}</div>
+        <div class="modal-titel">${d.titel}</div>
+        <div class="modal-meta">${d.akteur.join(', ')}</div>
+        <div class="modal-meta">${d.objekt.join(' · ')} <span class="card-op">${d.op}</span> ${strukturBadge}</div>
+        <div class="modal-badges">${drBadges}</div>
+        <hr class="modal-divider">
+        <div style="font-size:13px;color:var(--c-text-2);line-height:1.65;">${d.detail}</div>
+        <div class="detail-section" style="margin-top:12px;">
+          <div class="detail-section-label">Informationsdomäne</div>
+          ${domaeneHtml}
+        </div>
+        <div class="detail-section" style="margin-top:12px;">
+          <div class="detail-section-label">Rechtsgrundlagen <span style="font-weight:400;text-transform:none;letter-spacing:0;">(Entwurf)</span></div>
+          <div>${gesetzeHtml}</div>
+        </div>
+        <div class="detail-section" style="margin-top:12px;">
+          <div class="detail-section-label">Standards <span style="font-weight:400;text-transform:none;letter-spacing:0;">(Entwurf)</span></div>
+          <div>${standardsHtml}</div>
+        </div>`;
+
+      const panel = document.getElementById('modal-panel');
+      panel.className = `modal-panel phase-${d.phase}`;
+      document.getElementById('step-modal').style.display = 'flex';
     }
+
+    function closeModal(e) {
+      if (e && e.target !== document.getElementById('step-modal')) return;
+      document.getElementById('step-modal').style.display = 'none';
+    }
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') document.getElementById('step-modal').style.display = 'none';
+    });
 
     // ── Matrix Cross-Highlighting ────────────────────────────────────
     const matrixEl = document.getElementById('matrix-view');

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -545,6 +545,16 @@
       color: var(--c-text-1);
       background: var(--c-surface);
     }
+    .matrix-step-chip.phase-vor  { background: #D1FAE5; border-color: #6EE7B7; color: #065F46; }
+    .matrix-step-chip.phase-im   { background: #EDE9FE; border-color: #A78BFA; color: #3730A3; }
+    .matrix-step-chip.phase-nach { background: #FEF3C7; border-color: #FCD34D; color: #78350F; }
+    .matrix-step-chip.highlighted {
+      outline: 2px solid currentColor;
+      font-weight: 700;
+      opacity: 1 !important;
+      filter: brightness(0.92);
+    }
+    .matrix-step-chip.dimmed-by-hover { opacity: 0.2; }
 
     /* ── Print ── */
     @media print {
@@ -935,7 +945,7 @@
           const steps = matrix[domäne][dr];
           if (!steps.length) return `<td></td>`;
           const chips = steps.map(s =>
-            `<button class="matrix-step-chip" onclick="goToStep(${s.nr})">#${String(s.nr).padStart(2,'0')} ${s.titel}</button>`
+            `<button class="matrix-step-chip phase-${s.phase}" data-nr="${s.nr}" onclick="goToStep(${s.nr})">#${String(s.nr).padStart(2,'0')} ${s.titel}</button>`
           ).join('');
           return `<td>${chips}</td>`;
         }).join('');
@@ -960,6 +970,24 @@
         if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }, 50);
     }
+
+    // ── Matrix Cross-Highlighting ────────────────────────────────────
+    const matrixEl = document.getElementById('matrix-view');
+    matrixEl.addEventListener('mouseover', e => {
+      const chip = e.target.closest('.matrix-step-chip');
+      if (!chip) return;
+      const nr = chip.dataset.nr;
+      document.querySelectorAll('.matrix-step-chip').forEach(c => {
+        const same = c.dataset.nr === nr;
+        c.classList.toggle('highlighted',     same);
+        c.classList.toggle('dimmed-by-hover', !same);
+      });
+    });
+    matrixEl.addEventListener('mouseleave', () => {
+      document.querySelectorAll('.matrix-step-chip').forEach(c =>
+        c.classList.remove('highlighted', 'dimmed-by-hover')
+      );
+    });
 
     // ── Export-Funktionen ────────────────────────────────────────────
 

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -460,6 +460,92 @@
       }
     }
 
+    /* ── View-Tabs ── */
+    .view-tabs {
+      background: var(--c-surface);
+      border-bottom: 1px solid var(--c-border-1);
+      padding: 0 24px;
+      display: flex;
+    }
+    .view-tab {
+      padding: 10px 18px;
+      border: none;
+      border-bottom: 2px solid transparent;
+      background: transparent;
+      color: var(--c-text-3);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s;
+      margin-bottom: -1px;
+      font-family: inherit;
+    }
+    .view-tab:hover:not(.active) { color: var(--c-text-2); }
+    .view-tab.active {
+      color: var(--c-text-1);
+      border-bottom-color: var(--c-text-1);
+      font-weight: 600;
+    }
+
+    /* ── Matrix ── */
+    .matrix-wrap {
+      padding: 20px 24px;
+      overflow-x: auto;
+    }
+    .matrix-table {
+      border-collapse: collapse;
+      width: 100%;
+      font-size: 12px;
+    }
+    .matrix-table th {
+      padding: 8px 14px;
+      text-align: left;
+      border-bottom: 2px solid var(--c-border-1);
+      white-space: nowrap;
+    }
+    .matrix-table th:first-child {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--c-text-4);
+      min-width: 140px;
+    }
+    .matrix-table td {
+      padding: 8px 14px;
+      vertical-align: top;
+      border-bottom: 1px solid var(--c-border-1);
+      min-width: 180px;
+    }
+    .matrix-domaene {
+      font-weight: 600;
+      font-size: 13px;
+      color: var(--c-text-1);
+      white-space: nowrap;
+    }
+    .matrix-step-chip {
+      display: block;
+      width: 100%;
+      padding: 3px 8px;
+      border-radius: var(--r-sm);
+      font-size: 11px;
+      font-weight: 500;
+      background: var(--c-bg);
+      border: 1px solid var(--c-border-2);
+      color: var(--c-text-2);
+      cursor: pointer;
+      margin: 2px 0;
+      transition: all 0.1s;
+      text-align: left;
+      font-family: inherit;
+      line-height: 1.4;
+    }
+    .matrix-step-chip:hover {
+      border-color: var(--c-border-3);
+      color: var(--c-text-1);
+      background: var(--c-surface);
+    }
+
     /* ── Print ── */
     @media print {
       body { background: white; min-height: 0; }
@@ -480,6 +566,11 @@
   <div class="page-header">
     <h1>Patientenpfad – Interaktive Prozesskarte</h1>
     <p>Akteur &times; Prozess &rarr; Datenobjekt &nbsp;&middot;&nbsp; 25 Schritte &nbsp;&middot;&nbsp; 3 Phasen &nbsp;&middot;&nbsp; 4 Datenräume &nbsp;&middot;&nbsp; <a href="https://www.ina.gematik.de/mitwirken/arbeitskreise/rolle-von-patientenportalen-im-zusammenspiel-mit-primaersystemen-und-epa-1" target="_blank" style="color:inherit;opacity:0.6;text-decoration:none;">AK Patientenportale ↗</a></p>
+  </div>
+
+  <div class="view-tabs">
+    <button class="view-tab active" onclick="switchView('karten')">Prozessschritte</button>
+    <button class="view-tab" onclick="switchView('matrix')">Matrix</button>
   </div>
 
   <div class="print-filter-summary" id="print-filter-summary"></div>
@@ -534,6 +625,7 @@
       <button class="btn-export" onclick="exportJSON()" title="Sichtbare Schritte als JSON">↓ JSON</button>
     </div>
     <div id="karten"></div>
+    <div id="matrix-view" style="display:none;"></div>
   </div>
 
   <script src="patientenpfad_data.js"></script>
@@ -572,6 +664,7 @@
     // ── Filter-State ─────────────────────────────────────────────────
     const allStrukturen = ['strukturiert', 'teilstrukturiert', 'unstrukturiert'];
 
+    let activeView       = 'karten';
     let activePhase      = 'alle';
     let activeDR         = new Set(['portal','versorgung','epa','ehds']);
     let activeStrukturen = new Set(allStrukturen);
@@ -725,7 +818,7 @@
 
       return `
         <div class="prozess-card ${phaseBorder[d.phase]} ${dimmed ? 'dimmed' : ''} ${isOpen ? 'open' : ''}"
-             onclick="toggleDetail(${d.nr})">
+             data-nr="${d.nr}" onclick="toggleDetail(${d.nr})">
           <div class="card-meta">
             <span class="card-nr">#${String(d.nr).padStart(2,'0')}</span>
           </div>
@@ -803,6 +896,70 @@
     }
 
     render();
+
+    // ── View-Switching ───────────────────────────────────────────────
+    function switchView(view) {
+      activeView = view;
+      document.querySelectorAll('.view-tab').forEach((t, i) =>
+        t.classList.toggle('active', ['karten','matrix'][i] === view)
+      );
+      const isKarten = view === 'karten';
+      document.querySelector('.toolbar').style.display    = isKarten ? '' : 'none';
+      document.querySelector('.export-bar').style.display = isKarten ? '' : 'none';
+      document.getElementById('karten').style.display     = isKarten ? '' : 'none';
+      document.getElementById('matrix-view').style.display = isKarten ? 'none' : '';
+      if (!isKarten) renderMatrix();
+    }
+
+    // ── Matrix-Rendering ─────────────────────────────────────────────
+    function renderMatrix() {
+      const datenraeume = ['portal', 'versorgung', 'epa', 'ehds'];
+      const domaenen    = meta.domaenen;
+
+      const matrix = {};
+      domaenen.forEach(d => {
+        matrix[d] = {};
+        datenraeume.forEach(dr => { matrix[d][dr] = []; });
+      });
+      data.forEach(step => {
+        if (!step.domäne || !matrix[step.domäne]) return;
+        step.dr.forEach(dr => { matrix[step.domäne][dr].push(step); });
+      });
+
+      const thDR = datenraeume.map(dr =>
+        `<th><span class="dr-badge ${drBadgeClass[dr]}">${drLabel[dr]}</span></th>`
+      ).join('');
+
+      const rows = domaenen.map(domäne => {
+        const cells = datenraeume.map(dr => {
+          const steps = matrix[domäne][dr];
+          if (!steps.length) return `<td></td>`;
+          const chips = steps.map(s =>
+            `<button class="matrix-step-chip" onclick="goToStep(${s.nr})">#${String(s.nr).padStart(2,'0')} ${s.titel}</button>`
+          ).join('');
+          return `<td>${chips}</td>`;
+        }).join('');
+        return `<tr><td class="matrix-domaene">${domäne}</td>${cells}</tr>`;
+      }).join('');
+
+      document.getElementById('matrix-view').innerHTML = `
+        <div class="matrix-wrap">
+          <table class="matrix-table">
+            <thead><tr><th>Informationsdomäne</th>${thDR}</tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>`;
+    }
+
+    function goToStep(nr) {
+      switchView('karten');
+      openCard = nr;
+      render();
+      setTimeout(() => {
+        const card = document.querySelector(`.prozess-card[data-nr="${nr}"]`);
+        if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 50);
+    }
 
     // ── Export-Funktionen ────────────────────────────────────────────
 


### PR DESCRIPTION
## Was wurde umgesetzt

Neue Tab-Navigation im Viewer mit zwei Ansichten:

- **Prozessschritte** – bestehende Kachelansicht (unverändert)
- **Matrix** – neue Sicht: Informationsdomänen (Zeilen) × Datenräume (Spalten)

## Was die Matrix zeigt

Jede Zelle zeigt die Prozessschritte, die zu dieser Kombination aus Informationsdomäne und Datenraum gehören. Die Daten werden vollständig aus den vorhandenen Feldern `domäne` und `dr[]` abgeleitet – keine neuen Datenfelder notwendig.

## Visuelle Codierung

- **Phasenfarben** pro Chip: grün (vor dem Krankenhaus), indigo (im Krankenhaus), amber (nach dem Krankenhaus)
- **Cross-Highlighting beim Hover**: alle Vorkommen desselben Prozessschritts leuchten auf, der Rest wird gedimmt – Abhängigkeiten sind sofort erkennbar

## Navigation

Klick auf einen Chip wechselt zurück zur Kachelansicht und öffnet die Detailkarte des Schritts.

Closes #13