### PR TITLE
Viewer: Matrix-Legende, Hover-Fix und Druckübersicht (R2.5)

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -9,13 +9,13 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
 | `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
-| `patientenpfad_interaktiv.html` | v10 | 2026-04-30 | Matrix-Ansicht + Popup-Detail beim Chip-Klick |
+| `patientenpfad_interaktiv.html` | v11 | 2026-04-30 | Phasen-Legende, Hover-Fix, Druckübersicht (R2.5) |
 | `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
 | `patientenpfad_data.js` | v4 | 2026-04-29 | DIN EN ISO/IEEE 11073 ergänzt (meta + Schritte 9, 10, 12) |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
-| `KONTEXT.md` | – | 2026-04-30 | Session 2026-04-30 abgeschlossen |
+| `KONTEXT.md` | – | 2026-04-30 | Session 2026-04-30 (2) abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
 | `CLAUDE.md` | – | 2026-04-30 | Issue-Check in Start-Routine ergänzt |
 
@@ -124,7 +124,9 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | PR #8 (Standards-Filter + Auf-/Zuklappen + Struktur-Filter) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | PR #10 (Struktur-Filter + CLAUDE.md Commit-Konventionen) mergen | oeme-github | Erledigt (gemergt 2026-04-25) |
 | Issue #12 (DIN EN ISO/IEEE 11073 ergänzen) | Claude | Erledigt (2026-04-29) |
-| Issue #13 (Matrix-Ansicht Domänen × Datenräume) | Claude | Erledigt (2026-04-30) – PR #15 (inkl. Popup) |
+| Issue #13 (Matrix-Ansicht Domänen × Datenräume) | Claude | Erledigt (2026-04-30) – PR #15 gemergt |
+| R2.5 (Druckübersicht strukturierte Tabelle) | Claude | Erledigt (2026-04-30) – PR #16 |
+| Matrix-Legende + Hover-Fix | Claude | Erledigt (2026-04-30) – PR #16 |
 | Issue #14 (Ist-Analyse) | AG | Offen – wartet auf Entscheidung der Arbeitsgruppe |
 
 ---
@@ -150,7 +152,7 @@ Ziel: Eine interaktive, pflegbare Prozesslandkarte, die in der Arbeitsgruppe gen
 | R2.2 | Freitextsuche über Titel, Akteur, Objekt | Mittel | Erledigt (mit Highlighting) |
 | R2.3 | `sendPrompt()`-Button entfernen – toter Platzhalter | Hoch | Erledigt |
 | R2.4 | Detailkarte: `nr`, `domäne`, `standards` und `gesetze` anzeigen, sobald befüllt | Mittel | Erledigt |
-| R2.5 | Druckansicht / Export (alle sichtbaren Karten als strukturierte Übersicht) | Niedrig | Offen |
+| R2.5 | Druckansicht / Export (alle sichtbaren Karten als strukturierte Übersicht) | Niedrig | Erledigt |
 
 ### R3 – Pflegbarkeit & Architektur
 
@@ -196,7 +198,6 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 
 ### Im Tool
 - Issue #14 (Ist-Analyse) – wartet auf Entscheidung der AG: strukturiert in Daten aufnehmen oder im Word-Dokument belassen?
-- R2.5 (Druckansicht/Export) – Priorität Niedrig, noch offen
 
 ### Im Dokument
 - Systemebene (Kap. 8) könnte um weitere Ist-Analyse-Beispiele ergänzt werden

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -591,6 +591,20 @@
       color: var(--c-text-1);
       background: var(--c-surface);
     }
+    .matrix-legende {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 14px;
+      flex-wrap: wrap;
+    }
+    .matrix-legende-label {
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--c-text-4);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
     .matrix-step-chip.phase-vor  { background: #D1FAE5; border-color: #6EE7B7; color: #065F46; }
     .matrix-step-chip.phase-im   { background: #EDE9FE; border-color: #A78BFA; color: #3730A3; }
     .matrix-step-chip.phase-nach { background: #FEF3C7; border-color: #FCD34D; color: #78350F; }
@@ -1007,6 +1021,12 @@
 
       document.getElementById('matrix-view').innerHTML = `
         <div class="matrix-wrap">
+          <div class="matrix-legende">
+            <span class="matrix-legende-label">Phasen:</span>
+            <span class="matrix-step-chip phase-vor" style="cursor:default;display:inline-block;width:auto;">Vor dem Krankenhaus</span>
+            <span class="matrix-step-chip phase-im"  style="cursor:default;display:inline-block;width:auto;">Im Krankenhaus</span>
+            <span class="matrix-step-chip phase-nach" style="cursor:default;display:inline-block;width:auto;">Nach dem Krankenhaus</span>
+          </div>
           <table class="matrix-table">
             <thead><tr><th>Informationsdomäne</th>${thDR}</tr></thead>
             <tbody>${rows}</tbody>

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -1091,17 +1091,17 @@
     // ── Matrix Cross-Highlighting ────────────────────────────────────
     const matrixEl = document.getElementById('matrix-view');
     matrixEl.addEventListener('mouseover', e => {
-      const chip = e.target.closest('.matrix-step-chip');
+      const chip = e.target.closest('.matrix-step-chip[data-nr]');
       if (!chip) return;
       const nr = chip.dataset.nr;
-      document.querySelectorAll('.matrix-step-chip').forEach(c => {
+      document.querySelectorAll('.matrix-step-chip[data-nr]').forEach(c => {
         const same = c.dataset.nr === nr;
         c.classList.toggle('highlighted',     same);
         c.classList.toggle('dimmed-by-hover', !same);
       });
     });
     matrixEl.addEventListener('mouseleave', () => {
-      document.querySelectorAll('.matrix-step-chip').forEach(c =>
+      document.querySelectorAll('.matrix-step-chip[data-nr]').forEach(c =>
         c.classList.remove('highlighted', 'dimmed-by-hover')
       );
     });

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -690,7 +690,8 @@
     <div class="export-bar">
       <div class="counter" id="counter"></div>
       <button class="btn-export" id="btn-expand" onclick="toggleExpandAll()">⊞ Alle aufklappen</button>
-      <button class="btn-export" onclick="exportPDF()" title="Druckansicht öffnen">↓ PDF</button>
+      <button class="btn-export" onclick="exportUebersicht()" title="Strukturierte Tabellenübersicht drucken">↓ Übersicht</button>
+      <button class="btn-export" onclick="exportPDF()" title="Kachelansicht drucken">↓ PDF</button>
       <button class="btn-export" onclick="exportCSV()" title="Sichtbare Schritte als CSV">↓ CSV</button>
       <button class="btn-export" onclick="exportJSON()" title="Sichtbare Schritte als JSON">↓ JSON</button>
     </div>
@@ -1116,6 +1117,61 @@
         (!d.struktur || activeStrukturen.has(d.struktur)) &&
         (d.gesetze || []).some(g => activeLaws.has(getLawGroup(g)))
       );
+    }
+
+    function exportUebersicht() {
+      const visible = getVisibleData();
+      const dateText = new Date().toLocaleDateString('de-DE', { day:'2-digit', month:'2-digit', year:'numeric' });
+
+      const phaseColor = { vor: '#059669', im: '#4F46E5', nach: '#B45309' };
+      const rows = visible.map(d => `
+        <tr>
+          <td style="white-space:nowrap;font-weight:600;">#${String(d.nr).padStart(2,'0')}</td>
+          <td style="white-space:nowrap;">
+            <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${phaseColor[d.phase]};margin-right:5px;vertical-align:middle;"></span>${phaseLabel[d.phase]}
+          </td>
+          <td style="font-weight:500;">${d.titel}</td>
+          <td>${d.akteur.join(', ')}</td>
+          <td>${d.objekt.join('<br>')}</td>
+          <td style="text-align:center;font-weight:700;">${d.op}</td>
+          <td>${d.dr.map(r => drLabel[r]).join(', ')}</td>
+          <td>${d.domäne || '–'}</td>
+        </tr>`).join('');
+
+      const html = `<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Patientenpfad – Strukturierte Übersicht</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #111; margin: 24px 28px; }
+    h1 { font-size: 15px; font-weight: 700; margin: 0 0 4px; }
+    .meta { font-size: 10px; color: #666; margin-bottom: 18px; }
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #888; border-bottom: 2px solid #ddd; padding: 5px 8px; white-space: nowrap; }
+    td { padding: 5px 8px; border-bottom: 1px solid #eee; vertical-align: top; line-height: 1.4; }
+    tr:hover td { background: #f5f5f5; }
+    @media print { body { margin: 12px; } tr:hover td { background: none; } }
+  </style>
+</head>
+<body>
+  <h1>Patientenpfad – Strukturierte Übersicht</h1>
+  <div class="meta">${visible.length} von ${data.length} Prozessschritten &nbsp;·&nbsp; Stand: ${dateText} &nbsp;·&nbsp; AK Patientenportale · INA gematik</div>
+  <table>
+    <thead>
+      <tr>
+        <th>Nr</th><th>Phase</th><th>Titel</th><th>Akteur</th><th>Datenobjekt</th><th>Op</th><th>Datenräume</th><th>Informationsdomäne</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+</body>
+</html>`;
+
+      const w = window.open('', '_blank');
+      w.document.write(html);
+      w.document.close();
+      w.print();
     }
 
     function exportPDF() {


### PR DESCRIPTION
## Was wurde umgesetzt

### Phasen-Legende in der Matrix-Ansicht
Oberhalb der Matrix zeigt eine Legende die drei Phasenfarben (grün / indigo / amber) mit Beschriftung. Die Legende wird beim Hover über Prozessschritt-Chips nicht gedimmt.

### Hover-Fix
Der Cross-Highlighting-Selektor wurde auf `[data-nr]` eingeschränkt, sodass nur echte Prozessschritt-Chips gedimmt werden – nicht die Legende.

### R2.5 – Strukturierte Druckübersicht
Neuer Button **↓ Übersicht** in der Export-Leiste. Öffnet eine druckfertige Tabellenansicht aller sichtbaren Prozessschritte in einem neuen Fenster:

- Spalten: Nr · Phase · Titel · Akteur · Datenobjekt · Op · Datenräume · Informationsdomäne
- Phasenpunkte farbkodiert (konsistent mit Matrix und Kachelansicht)
- Filterstand und Datum im Kopf der Tabelle
- Druckdialog wird automatisch geöffnet