### PR TITLE
Arbeitsdokument: Datenobjekte persistent/transient klargestellt (Issue #17)

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -8,14 +8,14 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
-| `patientenpfad_arbeitsdokument.md` | v3 | 2026-04-24 | Grundprinzip 3 korrigiert: „vor" statt „statt" |
+| `patientenpfad_arbeitsdokument.md` | v4 | 2026-05-07 | Kap. 4+6: Datenobjekte persistent/transient klargestellt (Issue #17) |
 | `patientenpfad_interaktiv.html` | v11 | 2026-04-30 | Phasen-Legende, Hover-Fix, Druckübersicht (R2.5) |
 | `patientenpfad_editor.html` | v2 | 2026-04-25 | Standards + Struktur-Select ergänzt |
 | `patientenpfad_data.js` | v4 | 2026-04-29 | DIN EN ISO/IEEE 11073 ergänzt (meta + Schritte 9, 10, 12) |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
-| `KONTEXT.md` | – | 2026-04-30 | Session 2026-04-30 (2) abgeschlossen |
+| `KONTEXT.md` | – | 2026-05-07 | Session 2026-05-07 abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
 | `CLAUDE.md` | – | 2026-04-30 | Issue-Check in Start-Routine ergänzt |
 
@@ -98,6 +98,9 @@ Die Pflege wurde bewusst als eigenständiger Akteur mit drei eigenen Prozessschr
 - Pflegedokumentation
 - Pflegerische Entlassungsplanung
 
+### Zu persistent vs. transient (Issue #17)
+Die AG hat Datenobjekte als reine Speicherobjekte missverstanden und den EHDS als „transaktional" bezeichnet. Beides ist berechtigt: Das Dokument verwendete „vorliegen" (Kap. 6), was Persistenz impliziert. Klarstellung in Kap. 4 und Kap. 6: Datenobjekte können persistent (Diagnose, Medikationsplan) oder transient (Terminanfrage, Nachricht) sein – die Unterscheidung trifft der Prozess. EHDS-Beschreibung um transaktionale Dimension ergänzt (MyHealth@EU).
+
 ### Zur Kommunikation / TI-Messenger
 Kommunikation wird systemunabhängig betrachtet. Der TI-Messenger ist eine Implementierung, keine Domäne. Kommunikation als Informationsdomäne existiert unabhängig vom Übertragungsweg.
 
@@ -128,6 +131,7 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | R2.5 (Druckübersicht strukturierte Tabelle) | Claude | Erledigt (2026-04-30) – PR #16 |
 | Matrix-Legende + Hover-Fix | Claude | Erledigt (2026-04-30) – PR #16 |
 | Issue #14 (Ist-Analyse) | AG | Offen – wartet auf Entscheidung der Arbeitsgruppe |
+| Issue #17 (Datenobjekte persistent/transient) | Claude | Erledigt (2026-05-07) – PR #18 |
 
 ---
 

--- a/patientenpfad_arbeitsdokument.md
+++ b/patientenpfad_arbeitsdokument.md
@@ -101,6 +101,8 @@ Die möglichen Operationen sind:
 
 Ein Datenobjekt gilt als erzeugt **(E)**, wenn es im Kontext des jeweiligen Prozessschritts erstmalig vorliegt – unabhängig davon, ob es an anderer Stelle bereits existiert.
 
+Ein Datenobjekt ist eine Informationseinheit im Kontext eines Prozessschritts. Es kann **persistent** sein – gespeichert und über den Prozessschritt hinaus verfügbar (z. B. Diagnose, Pflegedokumentation, Medikationsplan) – oder **transient** – erzeugt, übermittelt und danach nicht mehr als eigenständiges Objekt vorhanden (z. B. Terminanfrage, Nachricht, Check-in-Bestätigung). Diese Unterscheidung trifft der Prozess – nicht das System.
+
 | Phase | Prozessschritt | Akteur | Datenobjekt | Operation |
 |---|---|---|---|---|
 | Vor dem Krankenhaus | Termin anfragen / buchen | Patient, Verwaltung | Terminanfrage / Terminbestätigung | E |
@@ -157,14 +159,14 @@ Die im Prozessmodell identifizierten Datenobjekte lassen sich zu stabilen Inform
 
 ## 6. Datenräume im Patientenpfad
 
-Die im Prozess entstehenden Datenobjekte können in unterschiedlichen Datenräumen vorliegen.
+Die im Prozess entstehenden Datenobjekte können in unterschiedlichen Datenräumen auftreten – als persistent gespeicherte Objekte oder als transiente Objekte, die einen Prozessschritt durchlaufen.
 
 | Datenraum | Beschreibung |
 |---|---|
 | Versorgungssysteme | Systeme der Leistungserbringer – z. B. KIS, PVS |
 | Patientenportal | Patientenzentrierter Zugang zu Informationen und Kommunikation |
 | ePA | Bundesweite, sektorenübergreifende persönliche Patientenakte |
-| EHDS | Europäischer Gesundheitsdatenraum – länderübergreifende Verfügbarkeit von Gesundheitsdaten |
+| EHDS | Europäischer Gesundheitsdatenraum – länderübergreifende Verfügbarkeit und transaktionaler Austausch von Gesundheitsdaten; Datenobjekte werden hier oft durchgeleitet, nicht dauerhaft gespeichert (z. B. MyHealth@EU) |
 
 Diese Datenräume erfüllen unterschiedliche Funktionen – sind aber gleichwertig. Kein Datenraum ist führend. Die Architektur folgt nicht einem Systemfluss, sondern einer Informationsverteilung über Datenräume. Kommunikation findet dabei über alle Datenräume hinweg statt – unabhängig vom genutzten Übertragungsweg.
 


### PR DESCRIPTION
## Änderungen

- **Kap. 4**: Neuer Absatz erklärt, dass Datenobjekte persistent (z. B. Diagnose, Medikationsplan) oder transient (z. B. Terminanfrage, Nachricht) sein können. Die Unterscheidung trifft der Prozess – nicht das System.
- **Kap. 6**: Einleitungssatz von „vorliegen" auf „auftreten" geändert – neutraler und deckt beide Varianten ab.
- **Kap. 6, EHDS-Zeile**: Transaktionale Dimension des EHDS explizit gemacht (Datenobjekte werden oft durchgeleitet, nicht dauerhaft gespeichert; Verweis auf MyHealth@EU).

## Hintergrund

Rückmeldung der AG (Issue #17): Der EHDS wurde als transaktional bezeichnet, Datenobjekte als reine Speicherobjekte missverstanden. Diese Klarstellung behebt die konzeptionelle Unschärfe im Dokument.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)