### PR TITLE
Ist-Analyse: Schritte 1-6 ueberarbeitet und vereinheitlicht

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -8,15 +8,15 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
-| `patientenpfad_arbeitsdokument.md` | v4 | 2026-05-07 | Kap. 4+6: Datenobjekte persistent/transient klargestellt (Issue #17) |
+| `patientenpfad_arbeitsdokument.md` | v5 | 2026-05-18 | Kap. 1: Rahmentext zu bestehenden technischen Lösungen ergänzt |
 | `patientenpfad_interaktiv.html` | v12 | 2026-05-11 | Neue Sektionen ist/luecke/forderungen in Detailkarte und Modal |
 | `patientenpfad_editor.html` | v3 | 2026-05-11 | GitHub-API-Integration, neue Felder ist/luecke/forderungen |
-| `patientenpfad_data.js` | v5 | 2026-05-11 | Felder ist/luecke/forderungen (Schritte 1–3 befüllt, 4–25 vorbereitet) |
+| `patientenpfad_data.js` | v6 | 2026-05-18 | ist/luecke/forderungen Schritte 1–6 überarbeitet und vereinheitlicht |
 | `ANLEITUNG_EDITOR.md` | – | 2026-05-11 | Neu: Token-Setup und Nutzung der GitHub-Speicherung |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
-| `KONTEXT.md` | – | 2026-05-11 | Session 2026-05-11 abgeschlossen |
+| `KONTEXT.md` | – | 2026-05-18 | Session 2026-05-18 abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
 
 ---
@@ -102,6 +102,15 @@ Die Pflege wurde bewusst als eigenständiger Akteur mit drei eigenen Prozessschr
 
 Die UAG „Vor Krankenhaus" hat in ihrer ersten Sitzung entschieden, auf Detailebene zu bleiben und pro Prozessschritt textuell zu beschreiben: Was ist da? / Was fehlt? / Forderungen. Diese Struktur wurde als drei neue Felder (`ist`, `luecke`, `forderungen`) im Datenmodell abgebildet. Schritte 1–3 sind mit dem UAG-Ergebnis befüllt, Schritte 4–25 warten auf weitere Sitzungen.
 
+### Zur Ist-Analyse: Umgang mit bestehender Technik (Session 2026-05-18)
+
+AG-Feedback: Technisch orientierte Mitglieder befürchten einen "Papiertiger", wenn bestehende technische Lösungen nicht berücksichtigt werden. Reaktion: Rahmentext in Kap. 1 des Arbeitsdokuments ergänzt — bestehende Lösungen (VSDM, ISiK, ePA, FHIR) sind explizit Ausgangspunkt der Ist-Analyse, nicht ihr Gegner. Die `ist`-Felder beschreiben jetzt konkret und wertschätzend, was heute bereits funktioniert.
+
+Inhaltliche Korrekturen aus der Sitzung:
+- KIM-Adresse ist ein Attribut des Hausarztes, nicht des Patienten (Patienten haben keine KIM-Adressen)
+- Die gematik hat kein Einwilligungsmanagement in der ePA eingeführt — der gesetzlich vorgesehene Widerspruch (SGB V § 342) wurde an die KIS delegiert
+- Die Anamnese wird als kontinuierlicher, akteursübergreifender Prozess beschrieben: einmal erheben, sektorenübergreifend verfeinern — nicht neu erzeugen
+
 ### Zur Online-Pflege (Editor GitHub-Integration)
 
 Der Editor kann `patientenpfad_data.js` jetzt direkt per GitHub REST API ins Repository schreiben. AG-Mitglieder benötigen einen GitHub Personal Access Token (classic, `repo`-Scope) und tragen ihn einmalig im ⚙-Panel ein. Anleitung: `ANLEITUNG_EDITOR.md`. Damit entfällt der manuelle Export/Commit-Workflow für die Datenpflege.
@@ -140,6 +149,7 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | Matrix-Legende + Hover-Fix | Claude | Erledigt (2026-04-30) – PR #16 |
 | Issue #14 (Ist-Analyse) | Claude | Erledigt (2026-05-11) – PR #19, PR #20 |
 | Issue #17 (Datenobjekte persistent/transient) | Claude | Erledigt (2026-05-07) – PR #18 |
+| Ist-Analyse Schritte 1–6 überarbeiten (AG-Feedback Papiertiger) | Claude | Erledigt (2026-05-18) – PR #23 |
 
 ---
 
@@ -209,7 +219,8 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 ## Offene Punkte & nächste Schritte
 
 ### Im Tool
-- Schritte 4–25: Felder `ist`, `luecke`, `forderungen` noch leer – Befüllung in weiteren UAG-Sitzungen
+- Schritte 1–6: `ist`, `luecke`, `forderungen` überarbeitet und vereinheitlicht (Session 2026-05-18, PR #23)
+- Schritte 7–25: Felder `ist`, `luecke`, `forderungen` noch leer – Befüllung in weiteren UAG-Sitzungen
 - Editor-Anleitung (`ANLEITUNG_EDITOR.md`) an AG-Mitglieder weitergeben, die Daten pflegen sollen
 
 ### Im Dokument

--- a/patientenpfad_arbeitsdokument.md
+++ b/patientenpfad_arbeitsdokument.md
@@ -17,6 +17,8 @@ Der gewählte Ansatz folgt bewusst dieser Reihenfolge:
 
 Die Systemebene wird zunächst ausgeklammert und erst später als Mapping auf Prozesse und Daten betrachtet.
 
+Das bedeutet nicht, dass bestehende technische Lösungen ignoriert werden. Im Gegenteil: Die Ist-Analyse zu jedem Prozessschritt benennt explizit, was heute bereits existiert und funktioniert — VSDM, ISiK, ePA-Infrastruktur, FHIR-Profile, IHE-Profile. Diese Bestandsaufnahme ist der Ausgangspunkt. Der Prozessrahmen gibt den Maßstab vor, an dem bestehende Lösungen gemessen und Lücken identifiziert werden. Was gut trägt, bleibt. Was fehlt, wird benannt.
+
 ---
 
 ## 2. These & Grundprinzipien

--- a/patientenpfad_arbeitsdokument.md
+++ b/patientenpfad_arbeitsdokument.md
@@ -1,7 +1,7 @@
 # Rolle von Patientenportalen im Zusammenspiel mit Primärsystemen und ePA
 ### Standardisierung des Datenaustauschs im Patientenpfad
 
-**Version 4 | Stand: 2026-05-07**
+**Version 5 | Stand: 2026-05-18**
 
 ---
 

--- a/patientenpfad_data.js
+++ b/patientenpfad_data.js
@@ -166,9 +166,9 @@ const data = [
     standards: ["HL7 FHIR R4 (Appointment)", "ISiK Terminplanung"],
     struktur: "unstrukturiert",
     detail: "Terminvereinbarung für ambulante Vorstellung oder stationäre Aufnahme. Das Portal ist die primäre Schnittstelle – der Patient löst den Prozess aus.",
-    ist: "Das Portal ist die primäre Schnittstelle für die Terminvereinbarung.",
-    luecke: "Eindeutige Identifikation des Patienten fehlt.\nIntegration der Systeme per FHIR-Standard noch nicht durchgängig.",
-    forderungen: "Datenbasis als Ausgangspunkt und Endpunkt für alle Systeme (Standard: FHIR)."
+    ist: "Krankenhausportale bieten heute Terminbuchungsfunktionen an — teils als eigenständige Lösungen, teils über den Terminservicedienst der KVen. Mit ISiK Terminplanung und HL7 FHIR Appointment existieren Standards für die strukturierte Abbildung von Terminen. Die Integration zwischen Portal und KIS ist in vielen Häusern bereits umgesetzt.",
+    luecke: "Der Patient ist beim Termin noch nicht eindeutig identifiziert — eine Verknüpfung mit bestehenden Stammdaten oder der ePA ist zu diesem Zeitpunkt nicht möglich. Die FHIR-Integration zwischen Portal und KIS ist nicht durchgängig umgesetzt. Die beim Termin erfassten Informationen (Grund, Vorgeschichte) werden nicht strukturiert in den weiteren Prozess überführt.",
+    forderungen: "Eindeutige Patientenidentifikation bereits bei der Terminbuchung etablieren.\nTerminbuchung als Startpunkt des Datenprozesses verstehen: erfasste Informationen strukturiert in den weiteren Patientenpfad überführen.\nDurchgängige FHIR-Integration zwischen Portal und KIS als Mindeststandard definieren (ISiK Terminplanung)."
   },
   {
     nr: 2,
@@ -183,9 +183,9 @@ const data = [
     standards: ["HL7 FHIR R4 (ServiceRequest)", "KBV FHIR-Basisprofile", "HL7 CDA R2"],
     struktur: "unstrukturiert",
     detail: "Die Überweisung wird im Kontext des Krankenhauses erstmalig bereitgestellt. Heute oft noch als Papier oder PDF – ein klassischer Medienbruch.",
-    ist: "Existiert heute nur in der Papierwelt.\neÜberweisung als Auftrag vorhanden.",
-    luecke: "Elektronische Einweisung / Überweisung fehlt durchgängig.\nFrühzeitiger Zugriff auf die ePA nicht möglich.\nIdentifikation des Patienten im Vorfeld fehlt.",
-    forderungen: "Frühe Identifikation des Patienten.\nFrüher Zugriff auf Einweisung/Überweisung.\nFrüher Zugriff auf die ePA."
+    ist: "Die Überweisung und Einweisung existieren heute überwiegend als Papier oder PDF — ein klassischer Medienbruch. Mit der eÜberweisung (KBV) ist ein erster elektronischer Standard im Aufbau. HL7 FHIR ServiceRequest und KBV FHIR-Basisprofile bieten eine strukturierte Grundlage für die Abbildung.",
+    luecke: "Die elektronische Überweisung ist noch nicht flächendeckend eingeführt — der Medienbruch (Papier, Fax, PDF) ist der Regelfall. Die Einweisung löst keinen automatischen Zugriff auf die ePA aus. Die enthaltenen strukturierten Informationen (Diagnose, Fragestellung) erreichen das Krankenhaus nicht maschinenlesbar und müssen manuell ins KIS übertragen werden.",
+    forderungen: "Elektronische Überweisung und Einweisung flächendeckend einführen — strukturiert, maschinenlesbar, auf Basis von FHIR ServiceRequest.\nEinweisung als Auslöser für den frühzeitigen ePA-Zugriff nutzen.\nPatientenidentifikation bereits mit der Einweisung verknüpfen, um Medienbrüche im weiteren Prozess zu vermeiden."
   },
   {
     nr: 3,
@@ -200,9 +200,9 @@ const data = [
     standards: ["HL7 FHIR R4 (Patient)", "IHE PIX/PDQ", "gematik VSDM", "ISiK Basismodul"],
     struktur: "strukturiert",
     detail: "Kontaktdaten und Versicherungsdaten werden erfasst oder aktualisiert. Datenobjekt kann sowohl neu entstehen als auch verändert werden.",
-    ist: "VSDM vorhanden (Meldeadresse über Register).\nErfassung am Aufnahmeschalter etabliert.",
-    luecke: "Angaben am Aufnahmeschalter stimmen oft nicht mit der Gesundheitskarte überein – Stammsatz wird daher nicht automatisch aktualisiert.\n\nFehlende Felder: E-Mail, Telefon (im Portal mit gedacht), abweichende Anschrift, Hausarzt und KIM-Adresse.",
-    forderungen: "Erweiterung und Harmonisierung der Stammdaten über Standards und Systeme hinweg.\nZiel: Kein mehrfaches Angeben derselben Daten an verschiedenen Stellen.\nAbgrenzung: VSDM als Grundlage; Patientenportale und KIS brauchen einen einheitlichen Standard."
+    ist: "Mit dem VSDM existiert eine funktionierende Infrastruktur für Versichertenstammdaten — Meldeadresse und Versicherungsstatus sind über die Gesundheitskarte abrufbar. Die Erfassung am Aufnahmeschalter ist in deutschen Krankenhäusern etabliert. ISiK Basismodul und IHE PIX/PDQ bieten Standards für die strukturierte Patientenidentifikation.",
+    luecke: "Angaben am Aufnahmeschalter stimmen häufig nicht mit den Daten auf der Gesundheitskarte überein — eine automatische Aktualisierung des Stammsatzes findet nicht statt. Für die Kommunikation über Patientenportale relevante Felder fehlen im VSDM: E-Mail, Telefon, abweichende Anschrift sowie Hausarzt inkl. dessen KIM-Adresse. Patient wird an mehreren Stellen neu erfasst, statt auf einen gemeinsamen Datensatz zuzugreifen.",
+    forderungen: "VSDM als Grundlage nutzen und um portalrelevante Felder erweitern (E-Mail, Telefon, Hausarzt inkl. KIM-Adresse).\nEinmalige Stammdatenerfassung als Prozessziel: Daten werden einmal erhoben und sektorenübergreifend genutzt — nicht mehrfach neu eingegeben.\nEinheitlichen Standard für Patientenidentifikation in Portal, KIS und ePA definieren (Grundlage: ISiK Basismodul, IHE PIX/PDQ)."
   },
   {
     nr: 4,
@@ -217,9 +217,9 @@ const data = [
     standards: ["HL7 FHIR R4 (DocumentReference)", "IHE MHD", "IHE XDS.b", "gematik ePA-Spezifikation"],
     struktur: "unstrukturiert",
     detail: "Upload oder Zugriff auf vorhandene Dokumente. Idealerweise strukturierte Datenobjekte – nicht PDFs.",
-    ist: "Heute haben wir die ePA ab dem ersten Besuch mit dem VSDM im Zugriff.\nUpload über Patientenportale.\nPatient bringt Dokumente in Papierform oder elektronisch mit.\nLink: https://simplifier.net/guide/kdl-implementierungsleitfaden-2025?version=current",
-    luecke: "Früher Zugriff auf ePA existiert nicht. Wunsch aus Krankenhaus ist ein frühzeitiger Zugriff, ideal wäre mit Einweisung/Überweisung.\nPoPP im Kontext Patientenportal könnte einen Zugriff auf die ePA ermöglichen.\nStrukturierte Informationen (z.B. Medikamente, Labor, etc.).\nStandards: KDL",
-    forderungen: "Früher Zugriff auf die ePA.\nEinfache Methode den Zugriff auch über das Patientenportal, Einweisung/Überweisung zu erhalten.\nZusendung der Befunde durch Vorbehandler.\nKrankenhaussysteme  müssen bereitgestellte Informationen effizient verarbeiten können (Abdeckung von Standards z.B. LOINC).\nKI-gestützte Analyse der Informationen - wie kann eine Weg in die KI-Unterstützung aussehen?"
+    ist: "Mit dem VSDM ist die ePA ab dem ersten institutionellen Kontakt (Versichertenkarte einlesen) grundsätzlich zugänglich — eine bereits funktionierende Infrastruktur. Patientenportale bieten Upload-Funktionen für Dokumente. Patienten bringen Befunde per Papier oder elektronisch mit. Mit der Klinischen Dokumentenliste (KDL) existiert ein Kategorisierungsstandard für Dokumente in der ePA.\nLink: https://simplifier.net/guide/kdl-implementierungsleitfaden-2025?version=current",
+    luecke: "Zugriff auf die ePA ist erst ab dem ersten institutionellen Kontakt möglich — nicht bereits bei Einweisung oder Überweisung. PoPP (Proof of Patient Presence) könnte im Kontext von Patientenportalen einen früheren Zugriff ermöglichen, ist aber noch nicht etabliert. Bereitgestellte Dokumente liegen überwiegend unstrukturiert vor (PDF) — strukturierte Informationen zu Medikamenten, Labor etc. fehlen. Die Klinische Dokumentenliste (KDL) ist vorhanden, wird aber nicht durchgängig genutzt.",
+    forderungen: "Frühzeitiger Zugriff auf die ePA — bereits ab Einweisung oder Überweisung, nicht erst ab erstem institutionellem Kontakt.\nZugriff über das Patientenportal ermöglichen, verknüpft mit Einweisung oder Überweisung.\nStrukturierte Zusendung von Vorbefunden durch Vorbehandler (Standard: LOINC, KDL).\nKrankenhaussysteme müssen bereitgestellte strukturierte Informationen automatisch verarbeiten können.\nKI-gestützte Aufbereitung bereitgestellter Vorbefunde als mittelfristiges Ziel definieren."
   },
   {
     nr: 5,
@@ -234,9 +234,9 @@ const data = [
     standards: ["HL7 CDA R2", "HL7 FHIR R4 (QuestionnaireResponse)", "ISIK 6 - Formular"],
     struktur: "unstrukturiert",
     detail: "Digitale medizinische Vorgeschichte. Zentrales Datenobjekt – wird im gesamten Pfad weitergenutzt. Sollte strukturiert vorliegen, nicht als Freitext.",
-    ist: "Heute oft in der medizinischen Aufnahme.\nLink: https://gemspec.gematik.de/ig/fhir/isik/formular/6.0.0-rc/index.html",
-    luecke: "Keine Übermittlung der Informationen über die Grenzen hinweg. \nEinheitliche Anamnese vom Hausarzt zum Facharzt und Krankenhäuser.",
-    forderungen: "Standard für Anamnese festlegen als strukturiertes Datenobjekt. \nAbbildung in der KIS, ePA und Patientenportalen."
+    ist: "ISiK Stufe 6 führt mit dem Formular-Modul einen neuen Standard für digitale Anamnese ein, der gezielt auf diesen Anwendungsfall zugeschnitten ist. HL7 FHIR QuestionnaireResponse ist ein reifer internationaler Standard. In der Praxis findet die Anamnese heute überwiegend in der medizinischen Aufnahme statt — digital in KIS-Systemen oder auf Papier.\nLink: https://gemspec.gematik.de/ig/fhir/isik/formular/6.0.0-rc/index.html",
+    luecke: "Der Anamneseprozess beginnt an jeder Sektorgrenze neu: Patientinnen und Patienten geben dieselben Informationen beim Hausarzt, beim Facharzt und im Krankenhaus wiederholt an. Das Datenobjekt \"Anamnese\" wird nicht weitergereicht und verfeinert, sondern bei jedem Akteur neu erzeugt. Der Prozess ist fragmentiert — nicht das Werkzeug fehlt, sondern die Prozesskontinuität.",
+    forderungen: "Die Anamnese als kontinuierlichen, akteursübergreifenden Prozess gestalten: einmal erheben, sektorenübergreifend verfeinern und ergänzen — nicht neu erzeugen.\nEinheitlichen Standard als technische Grundlage festlegen (ISiK Formular, FHIR QuestionnaireResponse), der diesen Prozess trägt.\nAnamnesedaten in KIS, ePA und Patientenportalen abrufbar und erweiterbar machen."
   },
   {
     nr: 6,
@@ -251,9 +251,9 @@ const data = [
     standards: ["HL7 FHIR R4 (Consent)", "gematik ePA-Spezifikation"],
     struktur: "unstrukturiert",
     detail: "Datenschutz und Behandlungseinwilligung. Einwilligung und Widerspruch sind eigenständige Datenobjekte mit unterschiedlicher rechtlicher Wirkung.",
-    ist: "Heterogene Systemlandschaften. Wenig Standards. Hohe Relevanz.\nAufklärungsprozesse im Krankenhaus.\nLink: https://simplifier.net/guide/einwilligungsmanagement?version=current",
-    luecke: "Einheitliche Grundstruktur und Standards (z.B. FHIR - Consent).\nConsent-Management.",
-    forderungen: "Abbildung von Consents in der ePA (z.B. für Studien oder Broad-Consent).\nAbbildung des Widerspruchs zur Zugriff und Befüllung der ePA -> aus den KIS zurück in die ePA.\nLösungsidee: Unabhängige Treuhandstellen als Verwalter der Consent-Informationen."
+    ist: "Der Widerspruch gegen Zugriff und Befüllung der ePA ist gesetzlich vorgesehen (SGB V § 342), wurde in der Umsetzung jedoch an die Krankenhaussysteme (KIS) delegiert — mit heterogenen, nicht standardisierten Lösungen als Ergebnis. HL7 FHIR Consent ist ein reifer Standard für die strukturierte Abbildung von Einwilligungen, wird aber nicht durchgängig eingesetzt. Aufklärungsprozesse in Krankenhäusern existieren, teils digital unterstützt, aber ohne einheitliche Grundlage.\nLink: https://simplifier.net/guide/einwilligungsmanagement?version=current",
+    luecke: "Ein einrichtungsübergreifendes, standardisiertes Consent-Management fehlt. Die Umsetzung des gesetzlich vorgesehenen Widerspruchs liegt bei den Krankenhaussystemen — ohne gemeinsame Datenstruktur oder Prozesslogik. Krankenhausportale sind in diesen Prozess nicht eingebunden. FHIR Consent wäre ein geeigneter Standard, ist aber nicht durchgängig implementiert.",
+    forderungen: "Einwilligungsmanagement in der ePA verankern — nicht in heterogenen Krankenhaussystemen.\nWiderspruch gegen Zugriff und Befüllung der ePA zentral und standardisiert abbilden, nicht an KIS delegieren.\nKrankenhausportale als Patientenschnittstelle einbinden — Einwilligungen und Widersprüche über das Portal erteilen und verwalten.\nConsent-Abbildung für weitere Anwendungsfälle ermöglichen (z.B. Studienteilnahme, Broad-Consent).\nUnabhängige Treuhandstellen als mögliches Modell für die Verwaltung von Consent-Informationen prüfen."
   },
 
   // ── Im Krankenhaus ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Zusammenfassung

- Rahmentext in Kap. 1 des Arbeitsdokuments ergaenzt: bestehende technische Loesungen (VSDM, ISiK, ePA, FHIR-Profile) werden explizit als Ausgangspunkt der Ist-Analyse benannt
- Schritte 1-6 in patientenpfad_data.js durchgaengig ueberarbeitet:
  - ist: konkrete, wertschaetzende Beschreibung bestehender Technik
  - luecke: praezisere Formulierungen, Prozessbueche staerker herausgearbeitet
  - forderungen: klare Anforderungen statt offener Fragen; Prozessfokus gestaerkt
  - Grammatik- und Formatfehler behoben

## Inhaltliche Korrekturen

- Schritt 3: KIM-Adresse als Attribut des Hausarztes klargestellt
- Schritt 5: Anamnese als kontinuierlichen, akteursuebergreifenden Prozess beschrieben
- Schritt 6: Faktenfehler korrigiert - kein Einwilligungsmanagement in der ePA; Widerspruch wurde an KIS delegiert

## Hintergrund

Reaktion auf AG-Feedback: Technisch orientierte Mitglieder sehen die Gefahr eines Papiertigers, wenn bestehende Loesungen nicht beruecksichtigt werden. Der neue Rahmentext und die ueberarbeiteten ist-Felder adressieren das direkt.

## Noch offen

- Schritte 7-25: ist, luecke, forderungen noch leer - Befuellung in weiteren UAG-Sitzungen