### PR TITLE
Positionspapier: Forderungen Präklinisch

### DIFF
--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -16,7 +16,8 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
-| `KONTEXT.md` | – | 2026-05-18 | Session 2026-05-18 abgeschlossen |
+| `forderungen_praeklinisch.md` | v1 | 2026-05-21 | Neu: Forderungen Präklinisch in drei Varianten |
+| `KONTEXT.md` | – | 2026-05-21 | Session 2026-05-21 abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
 
 ---
@@ -150,6 +151,7 @@ Die ePA ist heute dokumentenlastig. Das Ziel sind strukturierte Datenobjekte, di
 | Issue #14 (Ist-Analyse) | Claude | Erledigt (2026-05-11) – PR #19, PR #20 |
 | Issue #17 (Datenobjekte persistent/transient) | Claude | Erledigt (2026-05-07) – PR #18 |
 | Ist-Analyse Schritte 1–6 überarbeiten (AG-Feedback Papiertiger) | Claude | Erledigt (2026-05-18) – PR #23 |
+| Forderungen Präklinisch verdichten und als Positionspapier aufbereiten | Claude | Erledigt (2026-05-21) – PR offen |
 
 ---
 
@@ -222,6 +224,11 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 - Schritte 1–6: `ist`, `luecke`, `forderungen` überarbeitet und vereinheitlicht (Session 2026-05-18, PR #23)
 - Schritte 7–25: Felder `ist`, `luecke`, `forderungen` noch leer – Befüllung in weiteren UAG-Sitzungen
 - Editor-Anleitung (`ANLEITUNG_EDITOR.md`) an AG-Mitglieder weitergeben, die Daten pflegen sollen
+
+### Positionspapier
+- `forderungen_praeklinisch.md` enthält alle Forderungen aus Schritte 1–6 in drei Varianten: Einzelpunkte, Kernforderungen mit Bestandsaufnahme, Fließtext
+- Struktur: je Forderung „Was existiert → Was fehlt → Was wir fordern"
+- Nächster Schritt: Forderungen für die klinische Phase (Schritte 7–25) nach Befüllung der Ist-Analyse ergänzen
 
 ### Im Dokument
 - Systemebene (Kap. 8) könnte um weitere Ist-Analyse-Beispiele ergänzt werden

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -17,7 +17,7 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
 | `index.html` | v2 | 2026-04-29 | Startseite mit Viewer- und Editor-Karten |
 | `forderungen_praeklinisch.md` | v1 | 2026-05-21 | Neu: Forderungen Präklinisch in drei Varianten |
-| `KONTEXT.md` | – | 2026-05-21 | Session 2026-05-21 abgeschlossen |
+| `KONTEXT.md` | – | 2026-05-28 | Session 2026-05-28 abgeschlossen |
 | `README.md` | – | 2026-04-29 | GitHub-Pages-Link ergänzt |
 
 ---

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -72,6 +72,12 @@ Diese Formel ist der gemeinsame Anker der Gruppe. Kein Element kann ohne die and
 
 ---
 
+## Quellen und Artefakte der AG
+
+Originaldokumente (Präsentationen, Zusammenfassungen, UAG-Ergebnisse) liegen im SharePoint der gematik / KIG. Der Zugriff ist auf AK-Mitglieder beschränkt. Artefakte werden nicht ins Repository eingecheckt – relevante Inhalte fließen direkt in `patientenpfad_data.js` und `patientenpfad_arbeitsdokument.md` ein.
+
+---
+
 ## GitHub-Konfiguration
 
 ### Ruleset (Branch-Schutz für `main`)

--- a/KONTEXT.md
+++ b/KONTEXT.md
@@ -8,10 +8,10 @@ Dieses Dokument ist das lebende Gedächtnis des Projekts. Es wird zu Beginn jede
 
 | Datei | Version | Stand | Letzte Änderung |
 |---|---|---|---|
-| `patientenpfad_arbeitsdokument.md` | v5 | 2026-05-18 | Kap. 1: Rahmentext zu bestehenden technischen Lösungen ergänzt |
+| `patientenpfad_arbeitsdokument.md` | v6 | 2026-05-28 | Kap. 9.3: Differenzierung Patientenportal vs. Zuweiserportal ergänzt |
 | `patientenpfad_interaktiv.html` | v12 | 2026-05-11 | Neue Sektionen ist/luecke/forderungen in Detailkarte und Modal |
 | `patientenpfad_editor.html` | v3 | 2026-05-11 | GitHub-API-Integration, neue Felder ist/luecke/forderungen |
-| `patientenpfad_data.js` | v6 | 2026-05-18 | ist/luecke/forderungen Schritte 1–6 überarbeitet und vereinheitlicht |
+| `patientenpfad_data.js` | v7 | 2026-05-28 | ist/luecke/forderungen Schritte 7, 8, 13 befüllt (UAG Klinische Prozesse) |
 | `ANLEITUNG_EDITOR.md` | – | 2026-05-11 | Neu: Token-Setup und Nutzung der GitHub-Speicherung |
 | `.github/CODEOWNERS` | – | 2026-04-25 | oeme-github + msusky |
 | `CLAUDE.md` | – | 2026-04-25 | Session-Ende-Checkliste erweitert, Widget-Abschnitt aktualisiert |
@@ -229,6 +229,13 @@ Die Datenstruktur selbst ändert sich beim Übergang **nicht**. Der Wechsel auf 
 - `forderungen_praeklinisch.md` enthält alle Forderungen aus Schritte 1–6 in drei Varianten: Einzelpunkte, Kernforderungen mit Bestandsaufnahme, Fließtext
 - Struktur: je Forderung „Was existiert → Was fehlt → Was wir fordern"
 - Nächster Schritt: Forderungen für die klinische Phase (Schritte 7–25) nach Befüllung der Ist-Analyse ergänzen
+
+### UAG Klinische Prozesse (Session 2026-05-28)
+- Schritte 7, 8 und 13 mit UAG-Ergebnissen befüllt (`ist`, `luecke`, `forderungen`)
+- UAG hat die Methode angewendet und drei Prozesse als Beispiele ausgearbeitet: Terminbuchung → Schritt 7, Administrative Aufnahme → Schritt 8, Informationsbereitstellung → Schritt 13
+- UAG-Fazit: Methode funktioniert; nicht alle Schritte konnten bearbeitet werden
+- UAG empfiehlt Differenzierung Patientenportal vs. Zuweiserportal → als neuer Abschnitt 9.3 ins Arbeitsdokument übernommen
+- Weiterer AK zur Vertiefung dieser Differenzierung empfohlen
 
 ### Im Dokument
 - Systemebene (Kap. 8) könnte um weitere Ist-Analyse-Beispiele ergänzt werden

--- a/forderungen_praeklinisch.md
+++ b/forderungen_praeklinisch.md
@@ -1,0 +1,101 @@
+# Forderungen Präklinisch
+
+*UAG Patientenpfad — Stand: 2026-05-21*
+*Basis: Ist-Analyse Prozessschritte 1–6 (patientenpfad_data.js)*
+
+---
+
+## Variante A — Vollständige Einzelpunkte (21 Forderungen)
+
+### 1. Patientenidentifikation
+- Eindeutige Patientenidentifikation bereits bei der Terminbuchung etablieren
+- Patientenidentifikation mit der Einweisung/Überweisung verknüpfen, um Medienbrüche im weiteren Prozess zu vermeiden
+- Einheitlichen Standard für Patientenidentifikation in Portal, KIS und ePA definieren (ISiK Basismodul, IHE PIX/PDQ)
+
+### 2. Digitalisierung von Überweisung und Einweisung
+- Elektronische Überweisung und Einweisung flächendeckend einführen — strukturiert, maschinenlesbar, auf Basis von FHIR ServiceRequest
+- Einweisung als Auslöser für den frühzeitigen ePA-Zugriff nutzen
+
+### 3. Frühzeitiger ePA-Zugriff
+- Zugriff auf die ePA bereits ab Einweisung oder Überweisung ermöglichen — nicht erst ab erstem institutionellem Kontakt
+- Zugriff über das Patientenportal ermöglichen, verknüpft mit Einweisung oder Überweisung
+
+### 4. Stammdaten
+- VSDM als Grundlage nutzen und um portalrelevante Felder erweitern (E-Mail, Telefon, Hausarzt inkl. KIM-Adresse)
+- Einmalige Stammdatenerfassung als Prozessziel: Daten einmal erheben, sektorenübergreifend nutzen — nicht mehrfach neu eingeben
+
+### 5. Strukturierte Daten und Interoperabilität
+- Terminbuchung als Startpunkt des Datenprozesses: erfasste Informationen strukturiert in den weiteren Patientenpfad überführen
+- Durchgängige FHIR-Integration zwischen Portal und KIS als Mindeststandard (ISiK Terminplanung)
+- Strukturierte Zusendung von Vorbefunden durch Vorbehandler (LOINC, KDL)
+- Krankenhaussysteme müssen bereitgestellte strukturierte Informationen automatisch verarbeiten können
+
+### 6. Anamnese als kontinuierlicher Prozess
+- Anamnese einmal erheben, sektorenübergreifend verfeinern — nicht an jeder Sektorgrenze neu erzeugen
+- Einheitlicher Standard als technische Grundlage (ISiK Formular, FHIR QuestionnaireResponse)
+- Anamnesedaten in KIS, ePA und Patientenportalen abrufbar und erweiterbar machen
+
+### 7. Einwilligungs- und Consent-Management
+- Einwilligungsmanagement in der ePA verankern — nicht in heterogenen Krankenhaussystemen
+- Widerspruch gegen Zugriff und Befüllung der ePA zentral und standardisiert abbilden, nicht an KIS delegieren
+- Krankenhausportale als Patientenschnittstelle einbinden: Einwilligungen und Widersprüche über das Portal erteilen und verwalten
+- Consent-Abbildung für weitere Anwendungsfälle ermöglichen (Studienteilnahme, Broad-Consent)
+- Unabhängige Treuhandstellen als mögliches Modell für Consent-Verwaltung prüfen
+
+---
+
+## Variante B — Fünf Kernforderungen mit Bestandsaufnahme
+
+**1. Patientenidentifikation sektorenübergreifend lösen**
+*Was existiert:* VSDM ist funktionierende Infrastruktur für Versichertenstammdaten. ISiK Basismodul und IHE PIX/PDQ sind ausgereifte Standards. Die eGK ist gesetzlich verankert (SGB V § 291).
+*Was fehlt:* Portalrelevante Felder im VSDM, durchgängige Nutzung in allen Sektoren.
+
+**2. Elektronische Überweisung als Prozessauslöser etablieren**
+*Was existiert:* eÜberweisung (KBV) ist im Aufbau. FHIR ServiceRequest und KBV FHIR-Basisprofile sind technisch vorhanden. Die ePA ist ab erstem institutionellem Kontakt grundsätzlich zugänglich.
+*Was fehlt:* Flächendeckende Einführung, Verknüpfung Einweisung → ePA-Zugriff.
+
+**3. Strukturierte Daten statt Dokumente — FHIR als Mindeststandard**
+*Was existiert:* ISiK Terminplanung und FHIR Appointment sind spezifiziert. Die Klinische Dokumentenliste (KDL) ist als Kategorisierungsstandard für die ePA vorhanden. ISiK Stufe 6 bringt das Formular-Modul für digitale Anamnese.
+*Was fehlt:* Durchgängige, verpflichtende Umsetzung — nicht nur Spezifikation.
+
+**4. Einmal erheben, sektorenübergreifend nutzen**
+*Was existiert:* VSDM liefert bereits abrufbare Stammdaten. FHIR QuestionnaireResponse ist ein reifer internationaler Standard. ISiK Stufe 6 Formular ist gezielt auf diesen Anwendungsfall ausgelegt.
+*Was fehlt:* Prozesslogik und verbindliche Anforderung zur Weitergabe — nicht das Werkzeug.
+
+**5. Einwilligungsmanagement in der ePA verankern**
+*Was existiert:* Der Widerspruch gegen ePA-Befüllung ist gesetzlich vorgesehen (SGB V § 342). HL7 FHIR Consent ist ein reifer Standard. Die gematik ePA-Spezifikation ist technische Infrastruktur.
+*Was fehlt:* Zentrale, standardisierte Umsetzung — heute an KIS delegiert, ohne gemeinsame Grundlage.
+
+---
+
+## Variante C — Fließtext (Positionspapier-Stil)
+
+### 1. Patientenidentifikation sektorenübergreifend lösen
+
+Eine eindeutige Patientenidentifikation ist die Voraussetzung für jeden weiteren Datenprozess. Mit dem VSDM existiert bereits eine funktionierende Infrastruktur für Versichertenstammdaten; ISiK Basismodul und IHE PIX/PDQ sind ausgereifte Standards, die eine strukturierte Patientenidentifikation in Portal, KIS und ePA technisch ermöglichen.
+
+Was fehlt, ist die durchgängige Nutzung dieser Grundlagen über alle Sektoren hinweg — und ihre Erweiterung um portalrelevante Felder, die das VSDM heute nicht enthält: E-Mail-Adresse, Telefonnummer und die KIM-Adresse des Hausarztes. Wir fordern, diese Felder im VSDM zu ergänzen und einen einheitlichen Identifikationsstandard verbindlich einzuführen — beginnend mit der Terminbuchung als erstem Kontaktpunkt.
+
+### 2. Elektronische Überweisung als Prozessauslöser etablieren
+
+Die technischen Grundlagen für eine elektronische Überweisung sind vorhanden: Die eÜberweisung der KBV ist im Aufbau, FHIR ServiceRequest und KBV FHIR-Basisprofile bieten eine strukturierte Grundlage. Die ePA ist grundsätzlich ab dem ersten institutionellen Kontakt zugänglich.
+
+Der Regelfall ist heute dennoch Papier, Fax oder PDF — ein Medienbruch, der im weiteren Prozess zu manuellen Übertragungen und Informationsverlusten führt. Wir fordern die flächendeckende Einführung der elektronischen Überweisung als strukturiertes, maschinenlesbares Dokument auf Basis von FHIR ServiceRequest — und ihre Nutzung als Auslöser für den frühzeitigen ePA-Zugriff, der heute erst ab dem ersten institutionellen Kontakt möglich ist.
+
+### 3. Strukturierte Daten statt Dokumente — FHIR als Mindeststandard
+
+Die Spezifikationen sind vorhanden: ISiK Terminplanung und HL7 FHIR Appointment beschreiben den Terminprozess strukturiert. Die Klinische Dokumentenliste (KDL) stellt einen Kategorisierungsstandard für Dokumente in der ePA bereit. ISiK Stufe 6 führt mit dem Formular-Modul einen neuen Standard für die digitale Anamnese ein, der gezielt auf diesen Anwendungsfall zugeschnitten ist.
+
+Was fehlt, ist die verbindliche und flächendeckende Umsetzung — nicht mehr Spezifikation, sondern Anforderung. Wir fordern, die durchgängige FHIR-Integration zwischen Portal, KIS und ePA als Mindeststandard festzuschreiben. Systeme müssen bereitgestellte strukturierte Informationen automatisch verarbeiten können — das Einlesen von PDFs darf kein Regelfall bleiben.
+
+### 4. Einmal erheben, sektorenübergreifend nutzen
+
+Die technischen Werkzeuge für eine sektorenübergreifende Datenweitergabe existieren: Das VSDM liefert bereits heute abrufbare Stammdaten. FHIR QuestionnaireResponse ist ein reifer internationaler Standard für strukturierte Anamnese-Daten. ISiK Stufe 6 ist auf genau diesen Anwendungsfall ausgelegt.
+
+Das eigentliche Problem ist kein technisches — es ist ein Prozessproblem. Stammdaten, Anamnese und Vorbefunde werden an jeder Sektorgrenze neu erhoben, statt weitergegeben und verfeinert zu werden. Patientinnen und Patienten geben dieselben Informationen beim Hausarzt, beim Facharzt und im Krankenhaus wiederholt an. Wir fordern, das Prinzip „einmal erheben, sektorenübergreifend nutzen" als verbindliches Prozessziel zu verankern — und die vorhandenen technischen Standards zu seiner Umsetzung verpflichtend einzusetzen.
+
+### 5. Einwilligungsmanagement in der ePA verankern
+
+Die rechtliche und technische Grundlage ist gelegt: Der Widerspruch gegen Zugriff und Befüllung der ePA ist gesetzlich vorgesehen (SGB V § 342). HL7 FHIR Consent ist ein ausgereifter Standard für die strukturierte Abbildung von Einwilligungen. Die gematik ePA-Spezifikation stellt die technische Infrastruktur bereit.
+
+In der Umsetzung wurde die Verantwortung jedoch an die Krankenhaussysteme delegiert — mit heterogenen, nicht standardisierten Lösungen als Ergebnis. Patientenportale sind in diesen Prozess nicht eingebunden. Wir fordern, das Einwilligungsmanagement zentral in der ePA zu verankern, Patientenportale als primäre Schnittstelle für Einwilligungen und Widersprüche einzubinden und Consent-Modelle von Anfang an so zu gestalten, dass sie auch für weitere Anwendungsfälle — Studienteilnahme, Broad-Consent — tragfähig sind.

--- a/patientenpfad_arbeitsdokument.md
+++ b/patientenpfad_arbeitsdokument.md
@@ -261,6 +261,20 @@ Wie haben andere Länder vergleichbare Probleme gelöst? Welche Ansätze – etw
 **Pilotprozesse definieren**
 Welche zwei oder drei Prozessschritte eignen sich für eine erste modellhafte Umsetzung? Ziel ist ein konkreter Proof of Concept, der die Prinzipien in die Praxis überführt.
 
+### 9.3 Differenzierung: Patientenportal und Zuweiserportal
+
+Die UAG Klinische Prozesse empfiehlt, den Datenraum „Portal" künftig zu differenzieren. Bisher wird das Portal als einheitliche Schnittstelle behandelt – die Praxis zeigt jedoch zwei klar unterschiedliche Anwendungsfälle:
+
+| | Patientenportal | Zuweiserportal |
+|---|---|---|
+| **Nutzer** | Patient, Angehörige | Niedergelassene Ärzte, Kliniken |
+| **Zweck** | Zugang zu eigenen Gesundheitsdaten | Medizinische Zusammenarbeit |
+| **Typische Inhalte** | Befunde, Termine, Einwilligungen, Kommunikation mit Behandlungsteam | Einweisungen, Entlassberichte, Konsile |
+
+Diese Unterscheidung ist für die Weiterentwicklung der Anforderungen und des Positionspapiers relevant: Welche Datenobjekte und Prozesse gehören primär in welchen Portaltyp? Und welche Standards müssen je Portal-Typ erfüllt sein?
+
+Die Differenzierung wird in einem weiteren Arbeitskreis vertieft.
+
 ---
 
 ## Anhang: Vollständiger Prozessblumenstrauß

--- a/patientenpfad_data.js
+++ b/patientenpfad_data.js
@@ -271,9 +271,9 @@ const data = [
     standards: ["HL7 FHIR R4 (Encounter)", "IHE PIX/PDQ", "ISiK Basismodul"],
     struktur: "strukturiert",
     detail: "Bestätigung der Anwesenheit. Auslöser des stationären Prozesses – verbindet das Portal mit der Verwaltung.",
-    ist: "",
-    luecke: "",
-    forderungen: ""
+    ist: "Krankenhäuser bieten Terminbuchungsfunktionen im Portal an. Mit ISiK Terminplanung, HL7 FHIR Appointment und HL7 SIU existieren Standards für die strukturierte Abbildung von Terminen. Einzelne KIS-Hersteller bieten FHIR-Schnittstellen an; die Integration zwischen Portal und KIS ist in einigen Häusern bereits umgesetzt.",
+    luecke: "Viele KIS-Hersteller bieten FHIR-Schnittstellen für Terminbuchung noch nicht oder nur gegen hohen Aufpreis an. Eine durchgängige, standardisierte Integration zwischen Portal und KIS ist die Ausnahme, nicht die Regel.",
+    forderungen: "Portal- und KIS-Anbieter sollen ISiK Terminplanung und FHIR für Terminbuchung unterstützen.\nKrankenhäuser sollen bei Ausschreibungen die Unterstützung von ISiK und FHIR als Vergabekriterium verankern."
   },
   {
     nr: 8,
@@ -288,9 +288,9 @@ const data = [
     standards: ["HL7 v2", "HL7 FHIR R4 (Encounter)", "ISiK Basismodul"],
     struktur: "strukturiert",
     detail: "Fallanlage im KIS. Zentrales Datenobjekt für den gesamten stationären Aufenthalt.",
-    ist: "",
-    luecke: "",
-    forderungen: ""
+    ist: "Digitale Einwilligungs- und Aufklärungsprozesse sind in Krankenhäusern vorhanden, häufig über spezialisierte Drittsysteme. Einige Häuser ermöglichen bereits die digitale Unterzeichnung von Aufklärungsbögen. Die relevanten Rechtsgrundlagen (§ 347 SGB V, GenDG, § 630d BGB, DSGVO) sind bekannt und werden umgesetzt.",
+    luecke: "Einwilligungsdokumente sind sehr individuell und kaum standardisiert. Drittsysteme verursachen hohe Kosten. Bei den erzeugten Dokumenten handelt es sich meist um PDF-Dateien – keine strukturierten, maschinenlesbaren Daten.",
+    forderungen: "Einheitlichen technischen Standard für Einwilligungsdokumente definieren.\nDigitale Signatur (QES) per GesundheitsID, EUDI-Wallet oder BundID als Zielbild etablieren: Patient signiert Einwilligungen im Portal oder vor Ort mit QES.\nEinwilligungen strukturiert an nachfolgende Systeme übermitteln – nicht als PDF."
   },
   {
     nr: 9,
@@ -373,9 +373,9 @@ const data = [
     standards: ["HL7 FHIR R4 (DocumentReference)", "gematik ePA-Spezifikation", "ISiK Basismodul"],
     struktur: "teilstrukturiert",
     detail: "Ausgewählte Informationen werden dem Patienten im Portal bereitgestellt – z.B. Laborwerte. Strukturierte Daten ermöglichen eine sinnvolle Darstellung.",
-    ist: "",
-    luecke: "",
-    forderungen: ""
+    ist: "Das KIS ist das führende System für medizinische Dokumentation; von dort werden Daten an Portal, ePA und Archiv weitergeleitet. Für Labordaten existieren etablierte Standards (HL7v2, FHIR, LOINC). Patientenportale stellen heute Befunde und Berichte bereit, häufig als PDF. Für strukturierte Verlaufsdaten (z.B. Vitalparameter) werden SNOMED CT-Codes eingesetzt.",
+    luecke: "Doppelte Datenbereitstellung in Portal und ePA verursacht Redundanz und Inkonsistenz. Die ePA-Versionierung für vorläufige Dokumente ist unzureichend – vorläufige Entlassberichte gehören daher derzeit nicht in die ePA. Die ePA ist patientengeführt (Opt-out), was eine verlässliche Bereitstellung einschränkt. KIM-Adressen des Zuweisers sind nicht immer bekannt; im Krankenhaus kann die KIM-Adresse von Fall zu Fall wechseln. Ethische Fragen (z.B. bei lebensverändernden Diagnosen) erfordern Workflowsteuerung vor automatischer Bereitstellung.",
+    forderungen: "Grundsätzlich strukturierte Daten gemäß anerkannter Standards und Terminologien anstreben – für die ePA immer, im Portal zunächst auch PDF ausreichend.\nVorläufige Entlassberichte gehören ins Patientenportal, nicht in die ePA – erst bei funktionierender Versionierung in der ePA.\nSystem- und prozessübergreifendes Merkmal zur Workflowsteuerung bereitstellen (z.B. Verhinderung automatischen Uploads vor persönlichem Arzt-Patienten-Gespräch bei kritischen Befunden).\nVersand an Zuweiser primär über KIM."
   },
   {
     nr: 14,


### PR DESCRIPTION
## Was wurde geändert

### Session 2026-05-21
- `forderungen_praeklinisch.md` neu: Forderungen für die präklinische Phase (Schritte 1–6) in drei Varianten (Einzelpunkte, Kernforderungen mit Bestandsaufnahme, Fließtext)

### Session 2026-05-28
- `patientenpfad_data.js` (v7): `ist`, `luecke`, `forderungen` für Schritte 7, 8 und 13 befüllt – Quelle: UAG Klinische Prozesse
  - Schritt 7 (Digitaler Check-in): ISiK/FHIR-Integration, Terminbuchung
  - Schritt 8 (Administrative Aufnahme): QES, strukturierte Einwilligungen
  - Schritt 13 (Bereitstellung Informationen im Portal): strukturierte Daten, ePA-Versionierung, Workflowsteuerung
- `patientenpfad_arbeitsdokument.md` (v6): Neuer Abschnitt 9.3 – Differenzierung Patientenportal vs. Zuweiserportal (UAG-Empfehlung)
- `KONTEXT.md`: Hinweis auf SharePoint als Ablageort für AG-Artefakte ergänzt

## Was ist noch offen

- Schritte 9–12 und 14–18 (`im`-Phase): `ist`, `luecke`, `forderungen` noch leer – warten auf weitere UAG-Sitzungen
- Positionspapier: Abschnitt klinische Phase nach Befüllung der Ist-Analyse ergänzen
- Issue #22: Viewer – Akteure in Prozess-Kacheln anzeigen (noch offen)
- Differenzierung Patientenportal/Zuweiserportal: Vertiefung in weiterem AK geplant