### PR TITLE
Viewer: Akteure als Tags in Prozess-Kacheln anzeigen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Thumbs.db
 *.pdf
 *.docx
 
+# AG-Artefakte (Originale liegen im SharePoint der gematik/KIG)
+*.odt
+
 # Backup-Dateien (lokale Arbeitskopien)
 *_org.js
 *_backup.js

--- a/patientenpfad_interaktiv.html
+++ b/patientenpfad_interaktiv.html
@@ -251,9 +251,21 @@
     }
 
     .card-akteur {
-      font-size: 12px;
-      color: var(--c-text-3);
-      margin-bottom: 3px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+
+    .akteur-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 20px;
+      font-size: 11px;
+      font-weight: 500;
+      background: #EFF6FF;
+      color: #1E40AF;
+      border: 1px solid #BFDBFE;
     }
 
     .card-objekt {
@@ -918,7 +930,7 @@
             <span class="card-nr">#${String(d.nr).padStart(2,'0')}</span>
           </div>
           <div class="card-titel">${highlight(d.titel, searchTerm)}</div>
-          <div class="card-akteur">${highlight(d.akteur.join(', '), searchTerm)}</div>
+          ${d.akteur && d.akteur.length ? `<div class="card-akteur">${d.akteur.map(a => `<span class="akteur-tag">${highlight(a, searchTerm)}</span>`).join('')}</div>` : ''}
           <div class="card-objekt">
             ${highlight(d.objekt.join(' · '), searchTerm)}<span class="card-op">${d.op}</span>${d.struktur ? `<span class="struktur-badge struktur-${d.struktur}">${d.struktur}</span>` : ''}
           </div>


### PR DESCRIPTION
Closes #22

## Was wurde geändert

- Akteure werden in den Prozess-Kacheln jetzt als kompakte blaue Tags angezeigt (statt kommagetrennte Grautext-Liste)
- Neuer CSS-Style `.akteur-tag` (hellblau, konsistent mit bestehenden Chips)
- `.card-akteur` nutzt jetzt Flexbox mit `flex-wrap` für mehrzeilige Darstellung
- Kachel ohne Akteure zeigt keinen Leerraum