### PR TITLE
Tooling: Suche in viewer-db durchsucht auch Rechtsgrundlage/Standard

### DIFF
--- a/viewer-db/index.html
+++ b/viewer-db/index.html
@@ -633,7 +633,7 @@
     return safe.replace(new RegExp(`(${escTerm})`, 'ig'), '<mark>$1</mark>');
   }
 
-  const SEARCH_DIM_KEYS = ['akteur', 'objekt', 'detail'];
+  const SEARCH_DIM_KEYS = ['akteur', 'objekt', 'detail', 'gesetz', 'standard'];
   function matchesSearch(d) {
     if (!searchTerm) return true;
     const q = searchTerm.toLowerCase();


### PR DESCRIPTION
## Zusammenfassung
- Nutzer-Feedback beim Testen: Suche nach "DSGVO" lieferte keine Treffer, obwohl das Wort im Feld Rechtsgrundlage steht
- `SEARCH_DIM_KEYS` in `viewer-db/index.html` um `gesetz`/`standard` erweitert (bewusst breiter als das Original, das dafür nur die Filter-Chips hat)
- Ist/Lücke/Forderungen bleiben weiterhin ausgeschlossen (unverändert seit V07)

## Test plan
- [x] Suche "Angehörige" (Akteur) liefert weiterhin Treffer
- [x] Suche "DSGVO" (Rechtsgrundlage) liefert jetzt Treffer
- [x] Suche "HL7 FHIR" (Standard) liefert jetzt Treffer
- [x] Suche nach einem nur in "Ist-Zustand" vorkommenden Begriff liefert weiterhin keinen Treffer