### PR TITLE
Tooling: "+ Neu"-Button bei Dimensionen für Nicht-Admins ausgrauen

### DIFF
--- a/editor-db/index.html
+++ b/editor-db/index.html
@@ -273,7 +273,7 @@
       <div id="dimensions-view" style="display:none;">
         <div class="sidebar-header">
           <h2 id="dimension-count">Dimensionen</h2>
-          <button class="btn btn-primary" onclick="newDimension()">+ Neu</button>
+          <button class="btn btn-primary" id="new-dimension-btn" onclick="newDimension()">+ Neu</button>
         </div>
         <div id="new-dimension-slot"></div>
         <div class="step-list" id="dimension-list"></div>
@@ -430,6 +430,14 @@
     const memberships = await memberRes.json();
     myRole = memberships[0]?.rolle || null;
     document.getElementById('session-role').textContent = myRole || 'ohne Rolle';
+
+    // Neue Dimensionen anlegen erfordert laut RLS-Policy die Rolle admin
+    // (siehe Hinweis im Dimensionsformular) — Button ausgegraut statt
+    // anklickbar-aber-garantiert-403, damit Editoren nicht erst gegen die
+    // Wand laufen müssen, um das zu merken.
+    const newDimBtn = document.getElementById('new-dimension-btn');
+    newDimBtn.disabled = myRole !== 'admin';
+    newDimBtn.title = newDimBtn.disabled ? 'Neue Dimensionen anlegen erfordert die Rolle admin.' : '';
 
     await reloadDimensions();
     await reloadSteps();


### PR DESCRIPTION
## Zusammenfassung
- Nutzer-Feedback: Als `editor` sieht man den "+ Neu"-Button bei Dimensionen, obwohl neue Dimensionen laut RLS-Policy nur mit der Rolle `admin` angelegt werden können
- Ein Klick lief bisher korrekt gegen "Anlegen fehlgeschlagen (HTTP 403). Fehlt die admin-Rolle?" — funktional richtig, aber unnötig
- Button wird jetzt direkt nach dem Rollen-Check in `startApp()` deaktiviert (`myRole !== 'admin'`), mit Tooltip zur Begründung

## Test plan
- [x] Login als `editor` → Button in der Dimensionen-Ansicht ausgegraut, Tooltip erklärt warum
- [x] Login als `admin` → Button weiterhin aktiv/klickbar