### PR TITLE
Seed-Skript: Regression durch deferrable nr-Constraint (E08) behoben

### DIFF
--- a/supabase/seed/seed_ak_patientenportale.py
+++ b/supabase/seed/seed_ak_patientenportale.py
@@ -184,12 +184,26 @@ def upsert_dimensions(cur, workgroup_id: str, specs: list) -> dict:
 
 
 def upsert_process_step(cur, workgroup_id: str, nr: int, titel: str) -> str:
+    # kein ON CONFLICT (workgroup_id, nr): der Constraint ist seit E08
+    # (20260719090000_deferrable_process_steps_nr.sql) deferrable, und
+    # Postgres lässt deferrable Unique-Constraints nicht als ON-CONFLICT-
+    # Arbiter zu. Deshalb explizit UPDATE-dann-INSERT statt Upsert.
+    cur.execute(
+        """
+        update process_steps
+        set titel = %s, updated_at = now()
+        where workgroup_id = %s and nr = %s
+        returning id
+        """,
+        (titel, workgroup_id, nr),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row[0]
     cur.execute(
         """
         insert into process_steps (workgroup_id, nr, titel)
         values (%s, %s, %s)
-        on conflict (workgroup_id, nr) do update
-            set titel = excluded.titel, updated_at = now()
         returning id
         """,
         (workgroup_id, nr, titel),


### PR DESCRIPTION
## Zusammenfassung
- `seed_ak_patientenportale.py`s `upsert_process_step()` nutzte `ON CONFLICT (workgroup_id, nr)`
- Seit der E08-Migration (`20260719090000_deferrable_process_steps_nr.sql`) ist dieser Constraint `deferrable` — Postgres lässt deferrable Unique-Constraints aber nicht als `ON CONFLICT`-Arbiter zu
- Der Editor selbst ist nicht betroffen (bulk-upsertet per `on_conflict=id` gegen den Primärschlüssel), aber das Seed-Skript konnte seit PR #37 nicht mehr laufen
- Aufgefallen beim Datenabgleich (`reconcile_with_data_js.py`) für die Cutover-Checkliste: 3 Abweichungen bei den ersten Schritten (Reihenfolge-Rotation, vermutlich Rest vom E08-Testing)
- Fix: explizites UPDATE-dann-INSERT statt ON-CONFLICT-Upsert

## Testplan
- [x] \`python3 supabase/seed/seed_ak_patientenportale.py\` läuft ohne Fehler durch
- [x] \`python3 supabase/seed/reconcile_with_data_js.py\` läuft danach grün (25/25 identisch)